### PR TITLE
Add Discord push notification workflow for main branch only

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -1,0 +1,63 @@
+name: Notify Discord
+
+# Only pushes to main are announced in Discord. Other branches, tags and
+# force-push-to-empty are ignored on purpose -- a repo-level GitHub webhook
+# cannot filter by branch, which is why this lives in Actions instead.
+on:
+  push:
+    branches: ['main']
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Post push to Discord
+    runs-on: ubuntu-latest
+    if: github.event.head_commit != null
+    steps:
+      - name: Send Discord notification
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          PUSHER: ${{ github.event.pusher.name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          COMPARE_URL: ${{ github.event.compare }}
+          COMMITS: ${{ toJSON(github.event.commits) }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK_URL:-}" ]; then
+            echo "::warning::DISCORD_WEBHOOK_URL secret is not set - skipping notification"
+            exit 0
+          fi
+
+          count=$(printf '%s' "$COMMITS" | jq 'length')
+          subject=$(printf '%s' "$COMMIT_MSG" | head -n 1)
+
+          jq -n \
+            --arg repo "$REPO" \
+            --arg pusher "$PUSHER" \
+            --arg subject "$subject" \
+            --arg commit_url "$COMMIT_URL" \
+            --arg compare_url "$COMPARE_URL" \
+            --arg sha "${SHA:0:7}" \
+            --argjson count "$count" \
+            '{
+               username: "GitHub",
+               embeds: [{
+                 title: "[\($repo):main] \($count) new commit\(if $count == 1 then "" else "s" end)",
+                 url: $compare_url,
+                 color: 5814783,
+                 description: "[`\($sha)`](\($commit_url)) \($subject)",
+                 author: { name: $pusher }
+               }]
+             }' > payload.json
+
+          curl -sS --fail-with-body \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            --data @payload.json \
+            "$WEBHOOK_URL"


### PR DESCRIPTION
Repo-level GitHub webhooks cannot filter by branch, so every push on every branch was announced. This moves the notification into Actions where `on: push: branches: [main]` restricts it to main.

Payload is built with jq from env vars rather than inlined expressions, so commit messages containing shell metacharacters cannot inject into the runner. Skips with a warning when the DISCORD_WEBHOOK_URL secret is absent.

## Description
<!-- Please describe the motivation and context for this PR. -->

## Related Issue(s)
<!-- Fixes #123 (This auto-closes the issue when the PR merges) -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] I have read the `CONTRIBUTING.md` document.
- [ ] I have formatted my code using the project's linter.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.