### PR TITLE
Revert broken 'develop' merge — fixes editor black screen

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -2,7 +2,7 @@ name: Nightly Multi-Platform Build
 
 on:
   # push:
-  # branches: ['develop']
+       # branches: ['develop']
   # pull_request:
   #   branches: ['release/v1.0.0']
   # schedule:
@@ -218,7 +218,7 @@ jobs:
         run: |
           mkdir release-dist
           # Collect all installers and metadata files from all download paths
-          find release-assets -type f \( -name "*.dmg" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.exe" -o -name "latest*.yml" -o -name "latest*.json" \) -exec cp -v {} release-dist/ \;
+          find release-assets -type f \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.exe" -o -name "latest*.yml" -o -name "latest*.json" \) -exec cp -v {} release-dist/ \;
           echo "--- Assets collected for release ---"
           ls -R release-dist
 

--- a/packages/xgenia-editor/package.json
+++ b/packages/xgenia-editor/package.json
@@ -7,15 +7,15 @@
   "version": "2.1.1",
   "main": "src/main/main.bundle.js",
   "scripts": {
-    "build": "npm run build:node-docs && npx ts-node -P ./tsconfig.build.json ./scripts/build.ts",
-    "build:node-docs": "node scripts/compile-node-source-docs.js",
-    "watch:node-docs": "nodemon --watch ../xgenia-runtime/src/nodes --exec npm run build:node-docs",
+    "build": "npx ts-node -P ./tsconfig.build.json ./scripts/build.ts",
+    "build:renderer": "npx webpack --config=webpackconfigs/webpack.renderer.production.js && cp dist/bundles/src/editor/index.bundle.js src/editor/ && mkdir -p src/editor/bundles && find dist/bundles -maxdepth 1 -name '*.js' -exec cp {} src/editor/bundles/ \\;",
     "build:renderer:dev": "npx webpack --config=webpackconfigs/webpack.renderer.production.js --mode=development && cp dist/bundles/src/editor/index.bundle.js src/editor/",
     "clean-bundles": "rm -f src/main/main.bundle.js src/editor/index.bundle.js",
-    "rebuild-bundles": "npm run clean-bundles && npm run build:renderer:dev",
+    "check:assets": "node scripts/check-asset-references.js",
+    "rebuild-bundles": "npm run clean-bundles && npm run build:renderer",
     "start": "webpack-dev-server --config=webpackconfigs/webpack.renderer.dev.js",
-    "start:_dev": "electron dev-main.js --dev",
-    "start:_dev_webpack": "electron . --dev",
+    "start:_dev": "electron dev-main.js --dev --no-sandbox",
+    "start:_dev_webpack": "electron . --dev --no-sandbox",
     "dev": "npx ts-node scripts/dev.ts",
     "test": "webpack-dev-server --config=webpackconfigs/webpack.test.js",
     "test:_start_electron": "electron test.js",
@@ -39,7 +39,6 @@
         "dmg",
         "zip"
       ],
-      "artifactName": "${productName}-${version}-mac.${ext}",
       "hardenedRuntime": true,
       "notarize": false,
       "entitlements": "./build/entitlements.mac.plist",
@@ -53,8 +52,7 @@
       "target": "nsis"
     },
     "nsis": {
-      "guid": "XGENIA.net.XGENIA",
-      "artifactName": "${productName}-Setup-${version}.${ext}"
+      "guid": "XGENIA.net.XGENIA"
     },
     "linux": {
       "target": "deb"
@@ -156,6 +154,7 @@
     "otpauth": "^9.4.0",
     "passport": "0.7.0",
     "passport-local": "^1.0.0",
+    "prettier": "^3.8.1",
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-hot-toast": "^2.4.0",

--- a/packages/xgenia-editor/src/editor/src/templates/projectsview.html
+++ b/packages/xgenia-editor/src/editor/src/templates/projectsview.html
@@ -182,111 +182,6 @@
       color: #fff;
     }
 
-    /* New Project Choice Overlay */
-    .new-project-choice-overlay {
-      position: fixed;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.6);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
-      z-index: 900;
-      display: none;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .new-project-choice-overlay.visible {
-      display: flex;
-    }
-
-    .choice-panel {
-      background: rgba(22, 22, 24, 0.92);
-      backdrop-filter: blur(40px) saturate(180%);
-      -webkit-backdrop-filter: blur(40px) saturate(180%);
-      border-radius: 16px;
-      box-shadow: 0 0 0 0.5px rgba(255, 255, 255, 0.08), 0 24px 48px rgba(0, 0, 0, 0.5);
-      padding: 32px;
-      width: 440px;
-      max-width: 90vw;
-    }
-
-    .choice-panel-title {
-      font-size: 18px;
-      font-weight: 600;
-      color: rgba(255, 255, 255, 0.9);
-      margin: 0 0 4px;
-    }
-
-    .choice-panel-subtitle {
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.45);
-      margin: 0 0 24px;
-    }
-
-    .choice-card {
-      display: flex;
-      align-items: center;
-      gap: 14px;
-      padding: 16px;
-      border-radius: 10px;
-      background: rgba(255, 255, 255, 0.04);
-      border: 0.5px solid rgba(255, 255, 255, 0.06);
-      cursor: pointer;
-      transition: all 0.2s ease;
-      margin-bottom: 10px;
-    }
-
-    .choice-card:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: rgba(255, 255, 255, 0.12);
-    }
-
-    .choice-card:last-child {
-      margin-bottom: 0;
-    }
-
-    .choice-card-icon {
-      width: 40px;
-      height: 40px;
-      border-radius: 10px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-shrink: 0;
-      font-size: 18px;
-    }
-
-    .choice-card-title {
-      font-size: 14px;
-      font-weight: 600;
-      color: rgba(255, 255, 255, 0.85);
-      margin: 0 0 2px;
-    }
-
-    .choice-card-desc {
-      font-size: 12px;
-      color: rgba(255, 255, 255, 0.45);
-      margin: 0;
-    }
-
-    .choice-cancel {
-      display: block;
-      width: 100%;
-      text-align: center;
-      padding: 10px;
-      margin-top: 12px;
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.4);
-      background: none;
-      border: none;
-      cursor: pointer;
-      transition: color 0.2s ease;
-    }
-
-    .choice-cancel:hover {
-      color: rgba(255, 255, 255, 0.7);
-    }
-
 
     .projects-header-button {
       display: flex;
@@ -787,7 +682,7 @@
   <div class="projects-left-sidebar">
     <div style="flex: 1; overflow-y: auto; padding-top: 32px;">
       <div style="margin-bottom: 2rem;">
-        <button class="projects-create-new-project-button" data-click="onNewProjectButtonClicked">
+        <button class="projects-create-new-project-button" data-click="onCreateNewProjectClicked">
           <i class="hgi-stroke hgi-add-01" style="font-size: 15px;"></i>
           New project
         </button>
@@ -873,40 +768,8 @@
     </div>
   </div>
 
-    <!-- New Project Choice Overlay -->
-  <div id="new-project-choice-overlay" class="new-project-choice-overlay">
-    <div class="choice-panel">
-      <h3 class="choice-panel-title">New project</h3>
-      <p class="choice-panel-subtitle">How would you like to start?</p>
 
-      <div class="choice-card" data-click="onChoiceAIClicked">
-        <div class="choice-card-icon" style="background: rgba(103, 222, 146, 0.10); color: #67DE92;">
-          <i class="hgi-stroke hgi-artificial-intelligence-06"></i>
-        </div>
-        <div>
-          <div class="choice-card-title">Start with AI</div>
-          <p class="choice-card-desc">Describe your project and let AI build it for you</p>
-        </div>
-      </div>
 
-      <div class="choice-card" data-click="onChoiceTemplateClicked">
-        <div class="choice-card-icon" style="background: rgba(255, 255, 255, 0.06); color: rgba(255, 255, 255, 0.6);">
-          <i class="hgi-stroke hgi-layout-03"></i>
-        </div>
-        <div>
-          <div class="choice-card-title">Start from template</div>
-          <p class="choice-card-desc">Pick from pre-built templates and customise</p>
-        </div>
-      </div>
-
-      <button class="choice-cancel" data-click="onChoiceCancelClicked">Cancel</button>
-    </div>
-  </div>
-
-  <!-- AI Wizard mount point (React) -->
-  <div id="ai-wizard-root" style="position: absolute; inset: 0; z-index: 999; display: none;"></div>
-
-  
   <!-- Projects -->
   <div id="projectsPane"
     style="position: absolute; top:10px; bottom: 0px; left:240px; right:0px; background: transparent; padding: 8px 32px 16px 32px; overflow-y: auto;">

--- a/packages/xgenia-editor/src/editor/src/views/EditorTopbar/html-translator.ts
+++ b/packages/xgenia-editor/src/editor/src/views/EditorTopbar/html-translator.ts
@@ -305,7 +305,6 @@ function resolveFraction(value: string): string | undefined {
 }
 
 function parseTailwindClasses(classes: string | any, customColors?: Record<string, string>, customFonts?: Record<string, string>, customShadows?: Record<string, string>, customBackgroundImages?: Record<string, string>): ParsedStyles {
-function parseTailwindClasses(classes: string | any, customColors?: Record<string, string>, customFonts?: Record<string, string>, customShadows?: Record<string, string>, customBackgroundImages?: Record<string, string>): ParsedStyles {
     const styles: ParsedStyles = {};
     if (typeof classes !== 'string') {
         if (classes && classes.baseVal) classes = classes.baseVal; // Handle SVGAnimatedString explicitly
@@ -437,12 +436,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
             styles.styleCss = (styles.styleCss || '') + `grid-template-rows: repeat(${gridRowsMatch[1]}, minmax(0, 1fr));`;
             continue;
         }
-        // grid-rows-N → forward as styleCss so the renderer keeps row count if it honors grid
-        const gridRowsMatch = rawCls.match(/^grid-rows-(\d+)$/);
-        if (gridRowsMatch) {
-            styles.styleCss = (styles.styleCss || '') + `grid-template-rows: repeat(${gridRowsMatch[1]}, minmax(0, 1fr));`;
-            continue;
-        }
         // col-span-N → track how many grid columns this child spans
         const colSpanMatch = rawCls.match(/^col-span-(\d+)$/);
         if (colSpanMatch) { styles._colSpan = parseInt(colSpanMatch[1]); continue; }
@@ -468,64 +461,21 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
             styles.styleCss = (styles.styleCss || '') + `grid-auto-${axis === 'cols' ? 'columns' : 'rows'}: ${sizeMap[autoTrackMatch[2]]};`;
             continue;
         }
-        // row-span-N → forward via styleCss
-        const rowSpanMatch = rawCls.match(/^row-span-(\d+)$/);
-        if (rowSpanMatch) {
-            styles.styleCss = (styles.styleCss || '') + `grid-row: span ${rowSpanMatch[1]} / span ${rowSpanMatch[1]};`;
-            continue;
-        }
-        // grid-flow-col / grid-flow-row → styleCss
-        const gridFlowMatch = rawCls.match(/^grid-flow-(col|row)(-dense)?$/);
-        if (gridFlowMatch) {
-            const dir = gridFlowMatch[1];
-            const dense = gridFlowMatch[2] ? ' dense' : '';
-            styles.styleCss = (styles.styleCss || '') + `grid-auto-flow: ${dir}${dense};`;
-            continue;
-        }
-        // auto-cols-fr / auto-rows-fr / auto-cols-min / auto-cols-max / auto-cols-auto → styleCss
-        const autoTrackMatch = rawCls.match(/^auto-(cols|rows)-(fr|min|max|auto)$/);
-        if (autoTrackMatch) {
-            const axis = autoTrackMatch[1];
-            const sizeMap: Record<string, string> = { 'fr': 'minmax(0, 1fr)', 'min': 'min-content', 'max': 'max-content', 'auto': 'auto' };
-            styles.styleCss = (styles.styleCss || '') + `grid-auto-${axis === 'cols' ? 'columns' : 'rows'}: ${sizeMap[autoTrackMatch[2]]};`;
-            continue;
-        }
         if (rawCls === 'flex-col' || rawCls === 'flex-column') { styles.flexDirection = 'column'; continue; }
         if (rawCls === 'flex-col-reverse') { styles.flexDirection = 'column-reverse'; continue; }
-        if (rawCls === 'flex-col-reverse') { styles.flexDirection = 'column-reverse'; continue; }
         if (rawCls === 'flex-row') { styles.flexDirection = 'row'; continue; }
-        if (rawCls === 'flex-row-reverse') { styles.flexDirection = 'row-reverse'; continue; }
         if (rawCls === 'flex-row-reverse') { styles.flexDirection = 'row-reverse'; continue; }
         if (rawCls === 'flex-wrap') { styles.flexWrap = 'wrap'; continue; }
         if (rawCls === 'flex-wrap-reverse') { styles.flexWrap = 'wrap-reverse'; continue; }
         if (rawCls === 'flex-nowrap') { styles.flexWrap = 'nowrap'; continue; }
-        if (rawCls === 'flex-wrap-reverse') { styles.flexWrap = 'wrap-reverse'; continue; }
-        if (rawCls === 'flex-nowrap') { styles.flexWrap = 'nowrap'; continue; }
         if (rawCls === 'flex-1') { styles.flexGrow = 1; styles.flexShrink = 1; continue; }
-        if (rawCls === 'flex-auto') { styles.flexGrow = 1; styles.flexShrink = 1; styles.styleCss = (styles.styleCss || '') + 'flex-basis: auto;'; continue; }
-        if (rawCls === 'flex-initial') { styles.flexGrow = 0; styles.flexShrink = 1; continue; }
         if (rawCls === 'flex-auto') { styles.flexGrow = 1; styles.flexShrink = 1; styles.styleCss = (styles.styleCss || '') + 'flex-basis: auto;'; continue; }
         if (rawCls === 'flex-initial') { styles.flexGrow = 0; styles.flexShrink = 1; continue; }
         if (rawCls === 'flex-none') { styles.flexGrow = 0; styles.flexShrink = 0; continue; }
         if (rawCls === 'flex-grow' || rawCls === 'grow') { styles.flexGrow = 1; continue; }
         if (rawCls === 'flex-grow-0' || rawCls === 'grow-0') { styles.flexGrow = 0; continue; }
         if (rawCls === 'flex-shrink' || rawCls === 'shrink') { styles.flexShrink = 1; continue; }
-        if (rawCls === 'flex-grow-0' || rawCls === 'grow-0') { styles.flexGrow = 0; continue; }
-        if (rawCls === 'flex-shrink' || rawCls === 'shrink') { styles.flexShrink = 1; continue; }
         if (rawCls === 'flex-shrink-0' || rawCls === 'shrink-0') { styles.flexShrink = 0; continue; }
-        // basis-N → flex-basis
-        const basisMatch = rawCls.match(/^basis-(.+)$/);
-        if (basisMatch) {
-            const arb = basisMatch[1].match(/^\[(.+?)\]$/);
-            if (arb) { styles.styleCss = (styles.styleCss || '') + `flex-basis: ${arb[1]};`; continue; }
-            const frac = resolveFraction(basisMatch[1]);
-            if (frac) { styles.styleCss = (styles.styleCss || '') + `flex-basis: ${frac};`; continue; }
-            if (basisMatch[1] === 'full') { styles.styleCss = (styles.styleCss || '') + 'flex-basis: 100%;'; continue; }
-            if (basisMatch[1] === 'auto') { styles.styleCss = (styles.styleCss || '') + 'flex-basis: auto;'; continue; }
-            const v = resolveSpacing(basisMatch[1]);
-            if (v !== undefined) { styles.styleCss = (styles.styleCss || '') + `flex-basis: ${v}px;`; continue; }
-            continue;
-        }
         // basis-N → flex-basis
         const basisMatch = rawCls.match(/^basis-(.+)$/);
         if (basisMatch) {
@@ -592,19 +542,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
         if (rawCls === 'place-items-end') { styles.alignItems = 'flex-end'; styles.justifyContent = 'flex-end'; continue; }
 
         // ─── Gap / Space ────────────────────
-        // gap-x-N / gap-y-N must come BEFORE the bare gap-N matcher so they win.
-        const gapXMatch = rawCls.match(/^gap-x-(.+)$/);
-        if (gapXMatch) {
-            const v = resolveSpacing(gapXMatch[1]);
-            if (v !== undefined) styles.styleCss = (styles.styleCss || '') + `column-gap: ${v}px;`;
-            continue;
-        }
-        const gapYMatch = rawCls.match(/^gap-y-(.+)$/);
-        if (gapYMatch) {
-            const v = resolveSpacing(gapYMatch[1]);
-            if (v !== undefined) styles.styleCss = (styles.styleCss || '') + `row-gap: ${v}px;`;
-            continue;
-        }
         // gap-x-N / gap-y-N must come BEFORE the bare gap-N matcher so they win.
         const gapXMatch = rawCls.match(/^gap-x-(.+)$/);
         if (gapXMatch) {
@@ -711,42 +648,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
             if (v !== undefined) { styles.marginLeft = v * neg; styles.marginRight = v * neg; }
             continue;
         }
-        // m-N (all 4 sides) and m-auto must be matched BEFORE the per-side handlers
-        // so they don't get partially eaten.
-        const mAllMatch = rawCls.match(/^-?m-(.+)$/);
-        if (mAllMatch && !rawCls.startsWith('mx-') && !rawCls.startsWith('my-') &&
-            !rawCls.startsWith('mt-') && !rawCls.startsWith('mb-') &&
-            !rawCls.startsWith('ml-') && !rawCls.startsWith('mr-') &&
-            !rawCls.startsWith('-mx-') && !rawCls.startsWith('-my-') &&
-            !rawCls.startsWith('-mt-') && !rawCls.startsWith('-mb-') &&
-            !rawCls.startsWith('-ml-') && !rawCls.startsWith('-mr-') &&
-            !rawCls.startsWith('mix-') && !rawCls.startsWith('min-') &&
-            !rawCls.startsWith('max-')) {
-            if (mAllMatch[1] === 'auto') {
-                styles.styleCss = (styles.styleCss || '') + 'margin: auto;';
-                continue;
-            }
-            const neg = rawCls.startsWith('-') ? -1 : 1;
-            const v = resolveSpacing(mAllMatch[1]);
-            if (v !== undefined) {
-                const px = v * neg;
-                styles.marginTop = px; styles.marginBottom = px;
-                styles.marginLeft = px; styles.marginRight = px;
-            }
-            continue;
-        }
-        // mx-N (horizontal) — analogous to my-N
-        const mxMatch = rawCls.match(/^-?mx-(.+)$/);
-        if (mxMatch) {
-            if (mxMatch[1] === 'auto') {
-                styles.styleCss = (styles.styleCss || '') + 'margin-left: auto; margin-right: auto;';
-                continue;
-            }
-            const neg = rawCls.startsWith('-') ? -1 : 1;
-            const v = resolveSpacing(mxMatch[1]);
-            if (v !== undefined) { styles.marginLeft = v * neg; styles.marginRight = v * neg; }
-            continue;
-        }
         const mtMatch = rawCls.match(/^-?mt-(.+)$/);
         if (mtMatch) {
             const neg = rawCls.startsWith('-') ? -1 : 1;
@@ -792,10 +693,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
         if (rawCls === 'w-auto') { styles.width = 'auto'; continue; }
         if (rawCls === 'h-full') { styles.height = '100%'; continue; }
         if (rawCls === 'h-screen') { styles.height = '100%'; continue; }
-        if (rawCls === 'h-fit') { styles.height = 'fit-content'; continue; }
-        if (rawCls === 'h-min') { styles.height = 'min-content'; continue; }
-        if (rawCls === 'h-max') { styles.height = 'max-content'; continue; }
-        if (rawCls === 'h-auto') { styles.height = 'auto'; continue; }
         if (rawCls === 'h-fit') { styles.height = 'fit-content'; continue; }
         if (rawCls === 'h-min') { styles.height = 'min-content'; continue; }
         if (rawCls === 'h-max') { styles.height = 'max-content'; continue; }
@@ -976,67 +873,11 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
         if (rawCls === 'font-mono') { styles.fontFamily = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'; continue; }
         if (rawCls === 'font-sans') { styles.fontFamily = 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'; continue; }
         if (rawCls === 'font-serif') { styles.fontFamily = 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif'; continue; }
-        if (rawCls === 'normal-case') { styles.textTransform = 'none'; continue; }
-
-        // Font style (italic)
-        if (rawCls === 'italic') { styles.fontStyle = 'italic'; continue; }
-        if (rawCls === 'not-italic') { styles.fontStyle = 'normal'; continue; }
-
-        // Text decoration
-        if (rawCls === 'underline') { styles.styleCss = (styles.styleCss || '') + 'text-decoration: underline;'; continue; }
-        if (rawCls === 'line-through') { styles.styleCss = (styles.styleCss || '') + 'text-decoration: line-through;'; continue; }
-        if (rawCls === 'overline') { styles.styleCss = (styles.styleCss || '') + 'text-decoration: overline;'; continue; }
-        if (rawCls === 'no-underline') { styles.styleCss = (styles.styleCss || '') + 'text-decoration: none;'; continue; }
-        // decoration-{thickness, style, color}
-        const decorThickMatch = rawCls.match(/^decoration-(\d+|auto|from-font)$/);
-        if (decorThickMatch) {
-            const v = decorThickMatch[1];
-            const css = /^\d+$/.test(v) ? `${v}px` : v;
-            styles.styleCss = (styles.styleCss || '') + `text-decoration-thickness: ${css};`;
-            continue;
-        }
-        if (/^decoration-(solid|dashed|dotted|double|wavy)$/.test(rawCls)) {
-            styles.styleCss = (styles.styleCss || '') + `text-decoration-style: ${rawCls.replace('decoration-', '')};`;
-            continue;
-        }
-        const decorColorMatch = rawCls.match(/^decoration-(.+)$/);
-        if (decorColorMatch) {
-            const arb = decorColorMatch[1].match(/^\[(.+?)\]$/);
-            if (arb) {
-                styles.styleCss = (styles.styleCss || '') + `text-decoration-color: ${arb[1]};`;
-                continue;
-            }
-            const c = resolveColor(decorColorMatch[1], customColors);
-            if (c) {
-                styles.styleCss = (styles.styleCss || '') + `text-decoration-color: ${c};`;
-                continue;
-            }
-        }
-
-        // Default font-family stacks (font-mono, font-sans, font-serif)
-        if (rawCls === 'font-mono') { styles.fontFamily = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'; continue; }
-        if (rawCls === 'font-sans') { styles.fontFamily = 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'; continue; }
-        if (rawCls === 'font-serif') { styles.fontFamily = 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif'; continue; }
 
         // Text align
         if (rawCls === 'text-center') { styles.textAlign = 'center'; continue; }
         if (rawCls === 'text-left') { styles.textAlign = 'left'; continue; }
         if (rawCls === 'text-right') { styles.textAlign = 'right'; continue; }
-        if (rawCls === 'text-justify') { styles.textAlign = 'justify'; continue; }
-        if (rawCls === 'text-start') { styles.textAlign = 'start'; continue; }
-        if (rawCls === 'text-end') { styles.textAlign = 'end'; continue; }
-        // text-balance / text-pretty / text-wrap / text-ellipsis / text-clip
-        if (rawCls === 'text-balance') { styles.styleCss = (styles.styleCss || '') + 'text-wrap: balance;'; continue; }
-        if (rawCls === 'text-pretty') { styles.styleCss = (styles.styleCss || '') + 'text-wrap: pretty;'; continue; }
-        if (rawCls === 'text-wrap') { styles.styleCss = (styles.styleCss || '') + 'text-wrap: wrap;'; continue; }
-        if (rawCls === 'text-ellipsis') { styles.styleCss = (styles.styleCss || '') + 'text-overflow: ellipsis;'; continue; }
-        if (rawCls === 'text-clip') { styles.styleCss = (styles.styleCss || '') + 'text-overflow: clip;'; continue; }
-        // align-{baseline, top, middle, bottom, ...}
-        const alignVMatch = rawCls.match(/^align-(baseline|top|middle|bottom|text-top|text-bottom|sub|super)$/);
-        if (alignVMatch) {
-            styles.styleCss = (styles.styleCss || '') + `vertical-align: ${alignVMatch[1].replace('text-', 'text-')};`;
-            continue;
-        }
         if (rawCls === 'text-justify') { styles.textAlign = 'justify'; continue; }
         if (rawCls === 'text-start') { styles.textAlign = 'start'; continue; }
         if (rawCls === 'text-end') { styles.textAlign = 'end'; continue; }
@@ -1103,7 +944,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
         }
 
         // bg-COLOR (and bg-* utilities for size/position/repeat/attachment)
-        // bg-COLOR (and bg-* utilities for size/position/repeat/attachment)
         const bgColorMatch = rawCls.match(/^bg-(.+)$/);
         if (bgColorMatch) {
             const colorStr = bgColorMatch[1];
@@ -1113,54 +953,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
                 continue;
             }
             if (colorStr.startsWith('gradient')) continue;
-            // background-size utilities
-            if (colorStr === 'cover') { styles.styleCss = (styles.styleCss || '') + 'background-size: cover;'; continue; }
-            if (colorStr === 'contain') { styles.styleCss = (styles.styleCss || '') + 'background-size: contain;'; continue; }
-            if (colorStr === 'auto') { styles.styleCss = (styles.styleCss || '') + 'background-size: auto;'; continue; }
-            // background-position utilities
-            const POS_MAP: Record<string, string> = {
-                'center': 'center', 'top': 'top', 'bottom': 'bottom',
-                'left': 'left', 'right': 'right',
-                'left-top': 'left top', 'left-bottom': 'left bottom',
-                'right-top': 'right top', 'right-bottom': 'right bottom',
-            };
-            if (POS_MAP[colorStr] !== undefined) {
-                styles.styleCss = (styles.styleCss || '') + `background-position: ${POS_MAP[colorStr]};`;
-                continue;
-            }
-            // background-repeat utilities
-            if (colorStr === 'no-repeat' || colorStr === 'repeat' ||
-                colorStr === 'repeat-x' || colorStr === 'repeat-y' ||
-                colorStr === 'repeat-round' || colorStr === 'repeat-space') {
-                styles.styleCss = (styles.styleCss || '') + `background-repeat: ${colorStr};`;
-                continue;
-            }
-            // background-attachment utilities
-            if (colorStr === 'fixed' || colorStr === 'local' || colorStr === 'scroll') {
-                styles.styleCss = (styles.styleCss || '') + `background-attachment: ${colorStr};`;
-                continue;
-            }
-            // background-clip / background-origin
-            if (colorStr === 'clip-text') { styles._hasBgClipText = true; continue; }
-            if (colorStr === 'clip-border' || colorStr === 'clip-padding' || colorStr === 'clip-content') {
-                styles.styleCss = (styles.styleCss || '') + `background-clip: ${colorStr.replace('clip-', '')}-box;`;
-                continue;
-            }
-            if (colorStr === 'origin-border' || colorStr === 'origin-padding' || colorStr === 'origin-content') {
-                styles.styleCss = (styles.styleCss || '') + `background-origin: ${colorStr.replace('origin-', '')}-box;`;
-                continue;
-            }
-            // bg-blend-{normal, multiply, screen, overlay, ...}
-            const bgBlendMatch = colorStr.match(/^blend-(.+)$/);
-            if (bgBlendMatch) {
-                styles.styleCss = (styles.styleCss || '') + `background-blend-mode: ${bgBlendMatch[1]};`;
-                continue;
-            }
-            // Custom theme.extend.backgroundImage key (e.g. bg-metallic-rim → conic-gradient(...))
-            if (customBackgroundImages && customBackgroundImages[colorStr]) {
-                styles.styleCss = (styles.styleCss || '') + `background-image: ${customBackgroundImages[colorStr]};`;
-                continue;
-            }
             // background-size utilities
             if (colorStr === 'cover') { styles.styleCss = (styles.styleCss || '') + 'background-size: cover;'; continue; }
             if (colorStr === 'contain') { styles.styleCss = (styles.styleCss || '') + 'background-size: contain;'; continue; }
@@ -1276,9 +1068,7 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
         if (borderWMatch) { styles.borderWidth = parseInt(borderWMatch[1]); continue; }
 
         // Per-side borders: border-t, border-b, border-l, border-r, border-x, border-y (with optional width)
-        // Per-side borders: border-t, border-b, border-l, border-r, border-x, border-y (with optional width)
         // XGENIA doesn't have per-side border width, so emit via styleCss
-        const borderSideMatch = rawCls.match(/^border-([tblrxy])(?:-(\d+))?$/);
         const borderSideMatch = rawCls.match(/^border-([tblrxy])(?:-(\d+))?$/);
         if (borderSideMatch) {
             const width = borderSideMatch[2] ? parseInt(borderSideMatch[2]) : 1;
@@ -1350,56 +1140,6 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
         if (rawCls === 'inset-0') {
             styles.top = '0'; styles.bottom = '0'; styles.left = '0'; styles.right = '0';
             continue;
-        }
-        // General inset-N (all four sides), inset-x-N (left+right), inset-y-N (top+bottom),
-        // and their negative counterparts.
-        const insetAllMatch = rawCls.match(/^-?inset-(.+)$/);
-        if (insetAllMatch && !rawCls.startsWith('inset-x') && !rawCls.startsWith('inset-y') && !rawCls.startsWith('-inset-x') && !rawCls.startsWith('-inset-y')) {
-            const neg = rawCls.startsWith('-') ? '-' : '';
-            const arb = insetAllMatch[1].match(/^\[(.+?)\]$/);
-            if (arb) {
-                const v = `${neg}${arb[1]}`;
-                styles.top = v; styles.bottom = v; styles.left = v; styles.right = v;
-                continue;
-            }
-            const v = resolveSpacing(insetAllMatch[1]);
-            if (v !== undefined) {
-                const px = `${neg}${v}px`;
-                styles.top = px; styles.bottom = px; styles.left = px; styles.right = px;
-                continue;
-            }
-        }
-        const insetXMatch = rawCls.match(/^-?inset-x-(.+)$/);
-        if (insetXMatch) {
-            const neg = rawCls.startsWith('-') ? '-' : '';
-            const arb = insetXMatch[1].match(/^\[(.+?)\]$/);
-            if (arb) {
-                const v = `${neg}${arb[1]}`;
-                styles.left = v; styles.right = v;
-                continue;
-            }
-            const v = resolveSpacing(insetXMatch[1]);
-            if (v !== undefined) {
-                const px = `${neg}${v}px`;
-                styles.left = px; styles.right = px;
-                continue;
-            }
-        }
-        const insetYMatch = rawCls.match(/^-?inset-y-(.+)$/);
-        if (insetYMatch) {
-            const neg = rawCls.startsWith('-') ? '-' : '';
-            const arb = insetYMatch[1].match(/^\[(.+?)\]$/);
-            if (arb) {
-                const v = `${neg}${arb[1]}`;
-                styles.top = v; styles.bottom = v;
-                continue;
-            }
-            const v = resolveSpacing(insetYMatch[1]);
-            if (v !== undefined) {
-                const px = `${neg}${v}px`;
-                styles.top = px; styles.bottom = px;
-                continue;
-            }
         }
         // General inset-N (all four sides), inset-x-N (left+right), inset-y-N (top+bottom),
         // and their negative counterparts.
@@ -1916,117 +1656,8 @@ function parseTailwindClasses(classes: string | any, customColors?: Record<strin
             continue;
         }
 
-        // accent-COLOR / caret-COLOR
-        const accentMatch = rawCls.match(/^accent-(.+)$/);
-        if (accentMatch) {
-            const arb = accentMatch[1].match(/^\[(.+?)\]$/);
-            const c = arb ? arb[1] : resolveColor(accentMatch[1], customColors);
-            if (c) styles.styleCss = (styles.styleCss || '') + `accent-color: ${c};`;
-            continue;
-        }
-        const caretMatch = rawCls.match(/^caret-(.+)$/);
-        if (caretMatch) {
-            const arb = caretMatch[1].match(/^\[(.+?)\]$/);
-            const c = arb ? arb[1] : resolveColor(caretMatch[1], customColors);
-            if (c) styles.styleCss = (styles.styleCss || '') + `caret-color: ${c};`;
-            continue;
-        }
-        // outline utilities
-        if (rawCls === 'outline-none') { styles.styleCss = (styles.styleCss || '') + 'outline: none;'; continue; }
-        if (rawCls === 'outline') { styles.styleCss = (styles.styleCss || '') + 'outline-style: solid; outline-width: 1px;'; continue; }
-        if (rawCls === 'outline-dashed' || rawCls === 'outline-dotted' || rawCls === 'outline-double') {
-            styles.styleCss = (styles.styleCss || '') + `outline-style: ${rawCls.replace('outline-', '')};`;
-            continue;
-        }
-        const outlineWidthMatch = rawCls.match(/^outline-(\d+)$/);
-        if (outlineWidthMatch) {
-            styles.styleCss = (styles.styleCss || '') + `outline-width: ${outlineWidthMatch[1]}px; outline-style: solid;`;
-            continue;
-        }
-        const outlineOffsetMatch = rawCls.match(/^outline-offset-(\d+)$/);
-        if (outlineOffsetMatch) {
-            styles.styleCss = (styles.styleCss || '') + `outline-offset: ${outlineOffsetMatch[1]}px;`;
-            continue;
-        }
-        const outlineColorMatch = rawCls.match(/^outline-(.+)$/);
-        if (outlineColorMatch) {
-            const arb = outlineColorMatch[1].match(/^\[(.+?)\]$/);
-            const c = arb ? arb[1] : resolveColor(outlineColorMatch[1], customColors);
-            if (c) styles.styleCss = (styles.styleCss || '') + `outline-color: ${c};`;
-            continue;
-        }
-        // user-select / select-*
-        if (/^select-(none|text|all|auto)$/.test(rawCls)) {
-            styles.styleCss = (styles.styleCss || '') + `user-select: ${rawCls.replace('select-', '')};`;
-            continue;
-        }
-        // resize-* (button reset etc)
-        if (/^resize(-(none|y|x|both))?$/.test(rawCls)) {
-            const v = rawCls === 'resize' ? 'both' : rawCls.replace('resize-', '');
-            styles.styleCss = (styles.styleCss || '') + `resize: ${v};`;
-            continue;
-        }
-        if (rawCls === 'appearance-none') { styles.styleCss = (styles.styleCss || '') + 'appearance: none;'; continue; }
-        // cursor-* (not always desired but harmless)
-        const cursorMatch = rawCls.match(/^cursor-(.+)$/);
-        if (cursorMatch && !cursorMatch[1].startsWith('[')) {
-            styles.styleCss = (styles.styleCss || '') + `cursor: ${cursorMatch[1]};`;
-            continue;
-        }
-        // scroll-behavior
-        if (rawCls === 'scroll-smooth') { styles.styleCss = (styles.styleCss || '') + 'scroll-behavior: smooth;'; continue; }
-        if (rawCls === 'scroll-auto') { styles.styleCss = (styles.styleCss || '') + 'scroll-behavior: auto;'; continue; }
-        // will-change
-        const willChangeMatch = rawCls.match(/^will-change-(.+)$/);
-        if (willChangeMatch) {
-            styles.styleCss = (styles.styleCss || '') + `will-change: ${willChangeMatch[1]};`;
-            continue;
-        }
-        // place-content / place-self / content-* (align-content)
-        const placeContentMatch = rawCls.match(/^place-content-(start|end|center|between|around|evenly|baseline|stretch)$/);
-        if (placeContentMatch) {
-            const v = placeContentMatch[1];
-            const cssV = v === 'start' || v === 'end' ? `flex-${v}` : v === 'between' || v === 'around' || v === 'evenly' ? `space-${v}` : v;
-            styles.styleCss = (styles.styleCss || '') + `place-content: ${cssV};`;
-            continue;
-        }
-        const contentAlignMatch = rawCls.match(/^content-(start|end|center|between|around|evenly|baseline|stretch)$/);
-        if (contentAlignMatch) {
-            const v = contentAlignMatch[1];
-            const cssV = v === 'start' || v === 'end' ? `flex-${v}` : v === 'between' || v === 'around' || v === 'evenly' ? `space-${v}` : v;
-            styles.styleCss = (styles.styleCss || '') + `align-content: ${cssV};`;
-            continue;
-        }
-        const placeSelfMatch = rawCls.match(/^place-self-(auto|start|end|center|stretch)$/);
-        if (placeSelfMatch) {
-            const v = placeSelfMatch[1];
-            const cssV = v === 'start' || v === 'end' ? `flex-${v}` : v;
-            styles.styleCss = (styles.styleCss || '') + `place-self: ${cssV};`;
-            continue;
-        }
-        // justify-items / justify-self
-        const justifyItemsMatch = rawCls.match(/^justify-items-(start|end|center|stretch)$/);
-        if (justifyItemsMatch) {
-            styles.styleCss = (styles.styleCss || '') + `justify-items: ${justifyItemsMatch[1]};`;
-            continue;
-        }
-        const justifySelfMatch = rawCls.match(/^justify-self-(auto|start|end|center|stretch)$/);
-        if (justifySelfMatch) {
-            styles.styleCss = (styles.styleCss || '') + `justify-self: ${justifySelfMatch[1]};`;
-            continue;
-        }
-        // order-N / order-first / order-last / order-none
-        const orderMatch = rawCls.match(/^order-(\d+|first|last|none)$/);
-        if (orderMatch) {
-            const ORDER_MAP: Record<string, string> = { 'first': '-9999', 'last': '9999', 'none': '0' };
-            const v = ORDER_MAP[orderMatch[1]] !== undefined ? ORDER_MAP[orderMatch[1]] : orderMatch[1];
-            styles.styleCss = (styles.styleCss || '') + `order: ${v};`;
-            continue;
-        }
-
         // Skip misc utility classes
         if (rawCls === 'truncate' || rawCls === 'break-inside-avoid' ||
-            rawCls === 'no-scrollbar' || rawCls === 'group' || rawCls === 'peer') continue;
             rawCls === 'no-scrollbar' || rawCls === 'group' || rawCls === 'peer') continue;
 
         // font-FAMILY (custom Tailwind theme fonts like font-spooky, font-display)
@@ -2385,12 +2016,6 @@ function parseInlineStyle(styleStr: string): ParsedStyles {
                     value.includes('conic-gradient')
                 ) {
                     // Gradient background-image (e.g. dot grid pattern, conic wheel) → forward as CSS
-                } else if (
-                    value.includes('radial-gradient') ||
-                    value.includes('linear-gradient') ||
-                    value.includes('conic-gradient')
-                ) {
-                    // Gradient background-image (e.g. dot grid pattern, conic wheel) → forward as CSS
                     styles.styleCss = (styles.styleCss || '') + `background-image: ${value};`;
                 }
                 break;
@@ -2401,11 +2026,6 @@ function parseInlineStyle(styleStr: string): ParsedStyles {
                 break;
             }
             case 'background': {
-                if (
-                    value.includes('linear-gradient') ||
-                    value.includes('radial-gradient') ||
-                    value.includes('conic-gradient')
-                ) {
                 if (
                     value.includes('linear-gradient') ||
                     value.includes('radial-gradient') ||
@@ -3200,17 +2820,12 @@ const CONTAINER_TAGS = new Set([
     'figure', 'figcaption', 'details', 'summary', 'dialog', 'a', 'label',
     'menu', 'menuitem', 'pre', 'blockquote', 'address',
     'picture', // <picture> — falls through to first <img> fallback child
-    'form', 'fieldset', 'legend', 'ul', 'ol', 'li', 'dl', 'dt', 'dd',
-    'figure', 'figcaption', 'details', 'summary', 'dialog', 'a', 'label',
-    'menu', 'menuitem', 'pre', 'blockquote', 'address',
-    'picture', // <picture> — falls through to first <img> fallback child
 ]);
 
 // Tags that map to native XGENIA <button> node
 const BUTTON_TAGS = new Set(['button']);
 
 // Tags that represent text → <text>
-const TEXT_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'b', 'strong', 'em', 'i', 'kbd', 'code', 'mark', 'small', 'sub', 'sup', 'time', 'abbr', 'cite', 'q', 'samp', 'var']);
 const TEXT_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'b', 'strong', 'em', 'i', 'kbd', 'code', 'mark', 'small', 'sub', 'sup', 'time', 'abbr', 'cite', 'q', 'samp', 'var']);
 
 // Tags that imply bold text
@@ -3667,7 +3282,6 @@ function doTranslateHtmlToXgeniaXml(html: string, options?: { omitRootWrapper?: 
     // ─── Extract body-level styles (bg color, text color, flex, etc.) ────
     const bodyClassName = body.getAttribute('class') || '';
     const bodyStyles = parseTailwindClasses(bodyClassName, customColors, customFonts, customShadows, customBackgroundImages);
-    const bodyStyles = parseTailwindClasses(bodyClassName, customColors, customFonts, customShadows, customBackgroundImages);
     const bodyInline = body.getAttribute('style') ? parseInlineStyle(body.getAttribute('style')!) : {};
     const mergedBodyStyles: ParsedStyles = { ...bodyStyles, ...bodyInline };
 
@@ -3739,7 +3353,6 @@ function doTranslateHtmlToXgeniaXml(html: string, options?: { omitRootWrapper?: 
     // Translate body children
     const children = Array.from(body.childNodes)
         .map(node => translateNode(node, 1, customColors, cssClassStyles, fontFamily, undefined, cssDefinitions, customFonts, customShadows, customBackgroundImages))
-        .map(node => translateNode(node, 1, customColors, cssClassStyles, fontFamily, undefined, cssDefinitions, customFonts, customShadows, customBackgroundImages))
         .filter(Boolean);
 
     // Deduplicate: if consecutive children are identical (duplicated pages), keep only one
@@ -3753,8 +3366,6 @@ function doTranslateHtmlToXgeniaXml(html: string, options?: { omitRootWrapper?: 
     if (deduped.length === 0) {
         // Empty body — return a minimal wrapper unless caller wants no wrapper at all.
         return options?.omitRootWrapper ? '' : '<group nodeLabel="Root" width="100%" height="100%" />';
-        // Empty body — return a minimal wrapper unless caller wants no wrapper at all.
-        return options?.omitRootWrapper ? '' : '<group nodeLabel="Root" width="100%" height="100%" />';
     }
 
     // Emit CSS Definition nodes for collected CSS classes
@@ -3766,15 +3377,6 @@ function doTranslateHtmlToXgeniaXml(html: string, options?: { omitRootWrapper?: 
         cssDefs.push(`<css-definition style="${escapedCss}" />`);
     });
 
-    // Root group wraps visual children; CSS defs are siblings outside.
-    // omitRootWrapper: when the caller is inserting the result under an existing
-    // parent node (piecewise build), skip the outer Root group so we don't pile up
-    // @Root, @Root_2, @Root_3… ambiguous labels under the parent slot. The body's
-    // styles have already been lifted onto a child wrapper by the plugin's
-    // liftBodyStylesToRoot pass, so the children carry their own styling.
-    const rootXml = options?.omitRootWrapper
-        ? deduped.join('\n')
-        : `<group ${rootAttrs.join(' ')}>\n${deduped.join('\n')}\n</group>`;
     // Root group wraps visual children; CSS defs are siblings outside.
     // omitRootWrapper: when the caller is inserting the result under an existing
     // parent node (piecewise build), skip the outer Root group so we don't pile up
@@ -3887,17 +3489,6 @@ function generateNodeLabel(el: HTMLElement, tag: string, textHint?: string): str
         if (/-\[.+\]$/.test(stripped)) return false;
         // Skip purely-numeric/fractional utilities: `1/4`, `2/3`, `100%` (these slip through if class name is a fragment)
         if (/^\d+\/\d+$/.test(stripped)) return false;
-        // Strip a leading variant prefix so `dark:bg-X`, `md:flex`, `hover:opacity-50`, `lg:px-4`
-        // are filtered by the same rules as their plain counterparts.
-        const stripped = c.replace(/^(?:dark|hover|focus|active|disabled|group|sm|md|lg|xl|2xl|first|last|odd|even|peer|aria-[\w-]+|data-[\w-]+):/, '');
-        // Skip prefixed utilities: bg-, text-, border-, top-, right-, bottom-, left-, inset-, w-, h-, etc.
-        if (/^(flex|grid|gap|p[xytblr]?|m[xytblr]?|w|h|bg|text|font|border|rounded|shadow|overflow|relative|absolute|hidden|block|inline|items|justify|self|col|row|space|min|max|leading|tracking|z|opacity|transition|cursor|hover|focus|active|disabled|sm|md|lg|xl|2xl|top|right|bottom|left|inset|from|to|via|aspect|backdrop|divide|place|content|auto|order|basis|grow|shrink|float|clear|origin|rotate|scale|skew|translate|transform|filter|blur|brightness|contrast|grayscale|hue-rotate|invert|saturate|sepia|drop-shadow|backdrop-blur|backdrop-brightness|backdrop-contrast|backdrop-grayscale|backdrop-hue-rotate|backdrop-invert|backdrop-opacity|backdrop-saturate|backdrop-sepia|will-change|fill|stroke|caret|accent|outline|ring|ring-offset|tab|select|sr|cursor|resize|scroll|snap|touch|user|appearance|pointer|gradient)-/.test(stripped)) return false;
-        // Bare Tailwind utility names (no -)
-        if (/^(flex|grid|hidden|block|inline|relative|absolute|static|fixed|sticky|rounded|border|shadow|overflow|container|transform|transition|outline|ring|inset|truncate|antialiased|subpixel|clearfix|float|clear|table|contents|visible|invisible|sr|collapse|isolate|object|aspect|columns|break|decoration|underline|overline|italic|uppercase|lowercase|capitalize|ordinal|lining|tabular|proportional|diagonal|stacked|oldstyle|normal|backdrop|resize|snap|touch|select|appearance|pointer|will|scroll|overscroll|dark|group|peer|first|last|odd|even)$/.test(stripped)) return false;
-        // Skip arbitrary-value Tailwind classes like `top-[10px]`, `bg-[#392830]`, `w-[100vw]`
-        if (/-\[.+\]$/.test(stripped)) return false;
-        // Skip purely-numeric/fractional utilities: `1/4`, `2/3`, `100%` (these slip through if class name is a fragment)
-        if (/^\d+\/\d+$/.test(stripped)) return false;
         return true;
     });
 
@@ -3962,36 +3553,12 @@ function generateNodeLabel(el: HTMLElement, tag: string, textHint?: string): str
     // Decorative elements (dots, dividers, spacers) — extract a color/shape
     // descriptor so labels are distinguishable in the node tree instead of all
     // being "decorative border 1/2/3" which is un-targetable.
-    // Decorative elements (dots, dividers, spacers) — extract a color/shape
-    // descriptor so labels are distinguishable in the node tree instead of all
-    // being "decorative border 1/2/3" which is un-targetable.
     if (childCount === 0 && !effectiveText) {
         const hasBg = /background/.test(style);
         const hasBorder = /border/.test(style);
         const isCircle = /border-radius:\s*50%/.test(style) || /border-radius:\s*(100|999)/.test(style);
         const isShort = /height:\s*(1|2|3|4)px/.test(style);
 
-        // Try to pull a dominant color from the style for a more useful label.
-        const pickColor = (): string | null => {
-            // Hex first
-            const hexMatch = style.match(/#([0-9a-fA-F]{3,8})\b/);
-            if (hexMatch) return `#${hexMatch[1]}`;
-            // rgb/rgba
-            const rgbMatch = style.match(/rgba?\(([^)]+)\)/);
-            if (rgbMatch) return `rgb`;
-            // common named colors
-            const named = style.match(/(?:background(?:-color)?|color)\s*:\s*([a-z]+)/);
-            if (named && /^(red|orange|yellow|green|teal|cyan|blue|indigo|violet|purple|pink|magenta|white|black|gray|grey|silver|gold|chrome|neon)$/i.test(named[1])) return named[1].toLowerCase();
-            return null;
-        };
-        const color = pickColor();
-        const colorPrefix = color ? `${color} ` : '';
-
-        if (isCircle && hasBg) return `${colorPrefix}dot`.trim();
-        if (isShort && hasBg) return `${colorPrefix}divider`.trim();
-        if (hasBg && !hasBorder) return `${colorPrefix}panel`.trim();
-        if (hasBg && hasBorder) return `${colorPrefix}bordered panel`.trim();
-        if (hasBorder) return `${colorPrefix}border`.trim();
         // Try to pull a dominant color from the style for a more useful label.
         const pickColor = (): string | null => {
             // Hex first
@@ -4037,13 +3604,8 @@ function generateNodeLabel(el: HTMLElement, tag: string, textHint?: string): str
 /**
  * Short label for inline text nodes within containers.
  * Collapses whitespace runs so "BET         $25" → "BET $25".
- * Collapses whitespace runs so "BET         $25" → "BET $25".
  */
 function generateTextLabel(text: string): string {
-    if (!text) return 'text';
-    // Collapse all whitespace runs (including multi-space indentation pattern)
-    const collapsed = text.replace(/[\s ]+/g, ' ').trim();
-    const truncated = collapsed.substring(0, 30).trim();
     if (!text) return 'text';
     // Collapse all whitespace runs (including multi-space indentation pattern)
     const collapsed = text.replace(/[\s ]+/g, ' ').trim();
@@ -4092,8 +3654,6 @@ function translateNode(
     customFonts?: Record<string, string>,
     customShadows?: Record<string, string>,
     customBackgroundImages?: Record<string, string>
-    customShadows?: Record<string, string>,
-    customBackgroundImages?: Record<string, string>
 ): string | null {
     const indent = '  '.repeat(depth);
 
@@ -4129,7 +3689,6 @@ function translateNode(
 
     // Parse styles: Tailwind classes + inline style + CSS class styles
     const className = el.getAttribute('class') || '';
-    const twStyles = parseTailwindClasses(className, customColors, customFonts, customShadows, customBackgroundImages);
     const twStyles = parseTailwindClasses(className, customColors, customFonts, customShadows, customBackgroundImages);
     const inlineStyles = el.getAttribute('style') ? parseInlineStyle(el.getAttribute('style')!) : {};
 
@@ -4440,15 +3999,6 @@ function translateNode(
             'bi', 'bi-icon',
             'lucide', 'i-lucide',
         ];
-        // FontAwesome, Bootstrap Icons, Lucide, Heroicons (font/class form) don't use
-        // ligatures and depend on their JS/CSS runtimes — skip cleanly so the user's UI
-        // shows nothing rather than a broken empty span. (Heroicons used as inline SVG
-        // still works via the <svg> path.)
-        const SKIP_ICON_CLASSES = [
-            'fa', 'fas', 'far', 'fab', 'fal', 'fad', 'fa-solid', 'fa-regular', 'fa-brands',
-            'bi', 'bi-icon',
-            'lucide', 'i-lucide',
-        ];
         const elClasses = (el.getAttribute('class') || '').split(/\s+/);
 
         // data-lucide / data-feather / data-iconify hooks are JS-replaced — skip.
@@ -4551,7 +4101,6 @@ function translateNode(
                 if (childTag === 'span') {
                     const childClassName = childEl.getAttribute('class') || '';
                     const childStyles = parseTailwindClasses(childClassName, customColors, customFonts, customShadows, customBackgroundImages);
-                    const childStyles = parseTailwindClasses(childClassName, customColors, customFonts, customShadows, customBackgroundImages);
                     if (!childStyles.fontSize && styles.fontSize) {
                         childStyles.fontSize = styles.fontSize;
                     }
@@ -4571,7 +4120,6 @@ function translateNode(
                     // If this span has child elements (e.g. nested gradient spans),
                     // process it via translateNode to preserve nested structure
                     if (childEl.children.length > 0) {
-                        const translated = translateNode(childEl, depth + 1, customColors, cssClassStyles, fontFamily, styles.textAlign || parentTextAlign, cssDefinitions, customFonts, customShadows, customBackgroundImages);
                         const translated = translateNode(childEl, depth + 1, customColors, cssClassStyles, fontFamily, styles.textAlign || parentTextAlign, cssDefinitions, customFonts, customShadows, customBackgroundImages);
                         if (translated) children.push(translated);
                         continue;
@@ -4634,7 +4182,6 @@ function translateNode(
                         continue;
                     }
                 }
-                const translated = translateNode(child, depth + 1, customColors, cssClassStyles, fontFamily, styles.textAlign || parentTextAlign, cssDefinitions, customFonts, customShadows, customBackgroundImages);
                 const translated = translateNode(child, depth + 1, customColors, cssClassStyles, fontFamily, styles.textAlign || parentTextAlign, cssDefinitions, customFonts, customShadows, customBackgroundImages);
                 if (translated) children.push(translated);
             }
@@ -5053,7 +4600,6 @@ ${indent}</group>`;
                 }
             } else {
                 const translated = translateNode(child, depth + 1, customColors, cssClassStyles, fontFamily, styles.textAlign || parentTextAlign, cssDefinitions, customFonts, customShadows, customBackgroundImages);
-                const translated = translateNode(child, depth + 1, customColors, cssClassStyles, fontFamily, styles.textAlign || parentTextAlign, cssDefinitions, customFonts, customShadows, customBackgroundImages);
                 if (translated) children.push(translated);
             }
         }
@@ -5327,18 +4873,6 @@ function defaultTextColorFor(el: HTMLElement): string {
 }
 
 function createTextNode(el: HTMLElement, tag: string, text: string, styles: ParsedStyles, indent: string): string {
-    // Monospace defaults for code/keyboard/sample typographic tags.
-    if (!styles.fontFamily && (tag === 'code' || tag === 'kbd' || tag === 'samp' || tag === 'var')) {
-        styles = { ...styles, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace' };
-    }
-    // <mark> default: yellow highlight bg.
-    if (tag === 'mark' && !styles.backgroundColor) {
-        styles = { ...styles, backgroundColor: '#fef08a', color: styles.color || '#0f172a' };
-    }
-    // <small>: 80% size.
-    if (tag === 'small' && !styles.fontSize) {
-        styles = { ...styles, fontSize: 12 };
-    }
     // Monospace defaults for code/keyboard/sample typographic tags.
     if (!styles.fontFamily && (tag === 'code' || tag === 'kbd' || tag === 'samp' || tag === 'var')) {
         styles = { ...styles, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace' };

--- a/packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts
+++ b/packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts
@@ -19,23 +19,20 @@ import { recordAssetProvenance, loadAssetMeta, migrateAssetMeta } from '../Asset
 import { reconcileGraphAssetRefs } from '../AssetPanel/assetGraphRefs';
 import { ComponentModel } from '@xgenia-models/componentmodel';
 import { NodeGraphModel, NodeGraphNode } from '@xgenia-models/nodegraphmodel';
-import { NodeLibrary } from '@xgenia-models/nodelibrary';
-import { ProjectModel } from '@xgenia-models/projectmodel';
-import { SidebarModel } from '@xgenia-models/sidebar';
-import { UndoActionGroup, UndoQueue } from '@xgenia-models/undo-queue-model';
-import { guid } from '@xgenia-utils/utils';
-import { platform } from '@xgenia/platform';
 import { EventDispatcher } from '../../../../../shared/utils/EventDispatcher';
-import { supabase } from '../../../supabaseInit';
+import { guid } from '@xgenia-utils/utils';
 import {
-    addProjectPalette,
-    clearProjectBaseStyle,
     getProjectBaseStyleUrl,
+    setProjectBaseStyle,
+    clearProjectBaseStyle,
     getProjectGlobalStylePrompt,
+    setProjectGlobalStylePrompt,
     getProjectPalettes,
     addProjectPalette,
     getProjectBaseStyleId
 } from '../ProjectStylesPanel/ProjectStylesPanel';
+import { supabase } from '../../../supabaseInit';
+import { platform } from '@xgenia/platform';
 
 interface PluginCommand {
     id: string;
@@ -198,25 +195,6 @@ export class EditorBridge {
             );
         } catch (e: any) {
             console.warn('[EditorBridge] Could not listen for component changes:', e);
-        }
-    }
-
-    /** Listen for settings changes and push to plugin iframes */
-    private listenForSettingChanges() {
-        try {
-            const { EditorSettings } = require('../../../utils/editorsettings');
-            if (EditorSettings?.instance?.on) {
-                EditorSettings.instance.on('updated', ({ key }: any) => {
-                    if (key === 'fal.apiKey' || key === 'gemini.apiKey') {
-                        const value = EditorSettings.instance.get(key);
-                        console.log(`[EditorBridge] Setting updated: ${key}, pushing to plugins`);
-
-                        this.pushEvent('settingChanged', { key, value });
-                    }
-                }, this);
-            }
-        } catch (e: any) {
-            console.warn('[EditorBridge] Could not listen for setting changes:', e);
         }
     }
 
@@ -491,23 +469,6 @@ export class EditorBridge {
                 } else {
                     console.warn('[EditorBridge] No active component cached yet during initial state push');
                 }
-
-                // Check for a pending AI prompt from project creation (set by ProjectsView)
-                const pendingPrompt = (window as any).__xgenia_pendingAIPrompt;
-                if (pendingPrompt?.prompt) {
-                    console.log('[EditorBridge] Found pending AI prompt, will forward to ChatPanel');
-                    // Clear immediately to prevent re-delivery
-                    delete (window as any).__xgenia_pendingAIPrompt;
-                    // Delay slightly to let the plugin fully initialize its message handlers
-                    setTimeout(() => {
-                        this.pushEvent('initialPrompt', {
-                            prompt: pendingPrompt.prompt,
-                            images: pendingPrompt.images || [],
-                            selectedModel: pendingPrompt.selectedModel,
-                        });
-                        console.log('[EditorBridge] Pushed initialPrompt event to ChatPanel');
-                    }, 1000);
-                }
             }
         } catch (e: any) {
             console.warn('[EditorBridge] Could not push initial state:', e);
@@ -648,10 +609,8 @@ export class EditorBridge {
 
 
         h('html.translate', ([html, options]: [string, { omitRootWrapper?: boolean }?]) => {
-        h('html.translate', ([html, options]: [string, { omitRootWrapper?: boolean }?]) => {
             try {
                 const { translateHtmlToXgeniaXml } = require('../../EditorTopbar/html-translator');
-                return translateHtmlToXgeniaXml(html, options);
                 return translateHtmlToXgeniaXml(html, options);
             } catch (err: any) {
                 console.error('[EditorBridge] html.translate failed:', err.message);
@@ -739,24 +698,6 @@ export class EditorBridge {
                     }
                 }
 
-                // 2026-05-23 (BUG 76 fix, bridge half): refuse to create a
-                // ComponentInstance whose target is the currently active
-                // component. That produces a graph where the component
-                // contains itself; every getPorts()/forEachNode pass on it
-                // then recurses forever and crashes the editor with a
-                // stack overflow. Trace 2026-05-23 13:25 hit this when an
-                // AI passed `componentName: "/#__maths__/WildDoomMaths"`
-                // as the node type while the active component WAS
-                // /#__maths__/WildDoomMaths.
-                if (typeof nodeType === 'string' && nodeType.startsWith('/')) {
-                    const activeName = (graph as any)?.name || (graph as any)?.path || (graph as any)?.fullName;
-                    if (activeName && nodeType === activeName) {
-                        const msg = `Refusing to create ComponentInstance of "${nodeType}" inside itself — would produce a circular component reference that crashes the editor with a stack overflow on the next port lookup.`;
-                        console.error('[EditorBridge] graph.createNode SELF-INSTANCE BLOCKED:', msg);
-                        throw new Error(msg);
-                    }
-                }
-
                 // Use the canonical NodeGraphNode.fromJSON() pattern
                 // This is how XGENIA itself creates nodes (see NodeGraphModel.fromJSON)
                 const nodeId = guid();
@@ -798,38 +739,6 @@ export class EditorBridge {
                                 try { node.addPort({ name: p.name, plug: p.plug, type: p.type }); } catch { /* some nodes reject duplicates silently */ }
                             }
                         }
-                    }
-
-                    // FIX (2026-05-04): Hydrate PARAMETER DEFAULTS from the type's inputs schema.
-                    // Without this, hand-built pixi.ReelColumn / pixi.ReelCell nodes come out missing
-                    // animation params (spinSpeed, stopStyle, motionBlur, cellWidth, etc) — the
-                    // defaults are declared on type.inputs[key].default but fromJSON doesn't apply
-                    // them. The reel only animates correctly when a PixiReelController with
-                    // autoLayout cascades these values, which the AI doesn't always set up.
-                    // Apply any default that the node doesn't already have a value for.
-                    try {
-                        const inputs = type?.inputs;
-                        if (inputs && typeof inputs === 'object') {
-                            for (const paramName of Object.keys(inputs)) {
-                                const def = inputs[paramName];
-                                if (!def || def.default === undefined) continue;
-                                // Only set when the node doesn't already carry a value for this param
-                                const existing = (node as any).parameters?.[paramName];
-                                if (existing !== undefined && existing !== null) continue;
-                                try {
-                                    if (typeof (node as any).setParameter === 'function') {
-                                        (node as any).setParameter(paramName, def.default);
-                                    } else if ((node as any).parameters) {
-                                        (node as any).parameters[paramName] = def.default;
-                                    }
-                                } catch (perParamErr) {
-                                    // Some setters validate input strictly — skip on rejection
-                                    console.debug(`[EditorBridge] Default for ${typeName}.${paramName} rejected:`, (perParamErr as any)?.message);
-                                }
-                            }
-                        }
-                    } catch (paramHydrateErr: any) {
-                        console.warn('[EditorBridge] Parameter default hydration failed (non-fatal):', paramHydrateErr?.message);
                     }
 
                     // FIX (2026-05-04): Hydrate PARAMETER DEFAULTS from the type's inputs schema.
@@ -1308,21 +1217,7 @@ export class EditorBridge {
                 : connectionId.indexOf('->');
             const arrowLen = connectionId.includes('→') ? 1 : 2;
             if (!conn && arrowIdx > 0) {
-            // Strategy 2: Parse semantic format "fromId:fromProperty→toId:toProperty".
-            // 2026-06-01 (xgenia-debug-export-1779795859929 fix): also accept the
-            // ASCII "->" arrow. The edit_js_function_node ghost-cleanup path uses
-            // `conn.id` first (line 1748), and many GPL-side connection.id strings
-            // are built with "->", so the previous "→"-only branch rejected them
-            // outright and we threw "Connection not found" for connections that
-            // genuinely existed. Trace 2026-05-26 11:44 had four SpinResult /
-            // WinAmount / SpecialReel / CashCollect ghost-removals all fall here.
-            const arrowIdx = connectionId.indexOf('→') >= 0
-                ? connectionId.indexOf('→')
-                : connectionId.indexOf('->');
-            const arrowLen = connectionId.includes('→') ? 1 : 2;
-            if (!conn && arrowIdx > 0) {
                 const fromPart = connectionId.substring(0, arrowIdx);
-                const toPart = connectionId.substring(arrowIdx + arrowLen);
                 const toPart = connectionId.substring(arrowIdx + arrowLen);
                 const fColonIdx = fromPart.indexOf(':');
                 const tColonIdx = toPart.indexOf(':');
@@ -1339,8 +1234,6 @@ export class EditorBridge {
             }
 
             // Fallback for corrupted connections (e.g., from old addConnection bug)
-            if (!conn && (connectionId === 'undefined:undefined→undefined:undefined'
-                       || connectionId === 'undefined:undefined->undefined:undefined')) {
             if (!conn && (connectionId === 'undefined:undefined→undefined:undefined'
                        || connectionId === 'undefined:undefined->undefined:undefined')) {
                 const corruptIdx = connections.findIndex((c: any) => !c || typeof c === 'string' || (!c.fromId && !c.id));

--- a/packages/xgenia-editor/src/editor/src/views/panels/MathsPanel/MathsPanel.tsx
+++ b/packages/xgenia-editor/src/editor/src/views/panels/MathsPanel/MathsPanel.tsx
@@ -465,12 +465,7 @@ export function MathsPanel() {
 
     // Upload, Test & Deploy modal state
     const [showTestConfigModal, setShowTestConfigModal] = useState(false);
-    const [activeSimVersionId, setActiveSimVersionId] = useState<string | null>(null);
     const [simCount, setSimCount] = useState(10000);
-    const [simBetPort, setSimBetPort] = useState('bet');
-    const [simWinPort, setSimWinPort] = useState('win');
-    const [simAvailablePorts, setSimAvailablePorts] = useState<{ inputPorts: PortInfo[], outputPorts: PortInfo[] } | null>(null);
-    const [simInputConfig, setSimInputConfig] = useState<Record<string, InputConfig>>({});
     const [pipelineStep, setPipelineStep] = useState<string | null>(null);
 
     // Create Game modal state
@@ -1423,30 +1418,32 @@ export function MathsPanel() {
         }));
     }, [selectedGame]);
 
-    const handleUploadMathsComponent = useCallback(async (comp: any) => {
-        if (!settings?.apiKey) {
-            setUploadStatus({ type: 'error', message: 'Not connected to XRGS.' });
-            return;
-        }
-        if (!selectedGame) {
-            setUploadStatus({ type: 'error', message: 'No game selected.' });
-            return;
-        }
+
+
+    // Upload, Test & Deploy — full pipeline handler
+    const handleUploadTestDeploy = useCallback(async () => {
+        if (!settings?.apiKey || !selectedGame) return;
 
         setUploading(true);
         setUploadStatus(null);
-        setPipelineStep('Exporting component...');
+        setShowTestConfigModal(false);
+
+        const game = games?.find((g: any) => g.id === selectedGame);
+
         try {
-            const game = games?.find((g: any) => g.id === selectedGame);
+            // 1. Extract & sanitize the maths script
+            setPipelineStep('Extracting maths script...');
             const xrgs = (window as any).__xrgs;
             if (!xrgs?.generateRgsScript) {
-                setUploadStatus({ type: 'error', message: 'Maths bridge not ready.' });
+                setUploadStatus({ type: 'error', message: 'Maths bridge not ready. Open a maths component first.' });
                 setUploading(false);
                 setPipelineStep(null);
                 return;
             }
 
-            const result = xrgs.generateRgsScript(comp.name);
+            const result = xrgs.generateRgsScript();
+            (window as any).__xrgsLastScript = result.script;
+            console.log('[__xrgs] Script saved to window.__xrgsLastScript, length:', result.script?.length);
             if (result.error) {
                 setUploadStatus({ type: 'error', message: result.error });
                 setUploading(false);
@@ -1455,15 +1452,22 @@ export function MathsPanel() {
             }
 
             if (!result.script || result.script.length < 50) {
-                setUploadStatus({ type: 'error', message: 'Generated script is too short.' });
-                setUploading(false); setPipelineStep(null); return;
+                setUploadStatus({ type: 'error', message: 'Generated script is too short. Check your maths component.' });
+                setUploading(false);
+                setPipelineStep(null);
+                return;
             }
 
+            // Client-side compilation check
             try {
                 new Function('ctx', result.script);
+                console.log('[__xrgs] ✅ Client-side compilation check passed');
             } catch (compileErr: any) {
+                console.error('[__xrgs] ❌ Client-side compilation FAILED:', compileErr.message);
                 setUploadStatus({ type: 'error', message: `Client-side compilation failed: ${compileErr.message}` });
-                setUploading(false); setPipelineStep(null); return;
+                setUploading(false);
+                setPipelineStep(null);
+                return;
             }
 
             // 2. Test pipeline: upload → activate → stress-test, STOPPING at
@@ -1517,10 +1521,12 @@ export function MathsPanel() {
                 message: `${deployedName} → v${testRun.version} tested (not live). RTP ${rtpStr} · Hit ${hitStr} · Max ${maxStr}`,
             });
         } catch (e: any) {
-            setActionStatus({ id, type: 'error', msg: e.message || 'Action failed' });
+            setUploadStatus({ type: 'error', message: e.message || 'Pipeline failed' });
         }
-    };
 
+        setUploading(false);
+        setPipelineStep(null);
+    }, [settings, selectedGame, games, simCount]);
 
     return (
         <BasePanel title="Maths RGS" isFill>
@@ -2402,7 +2408,7 @@ export function MathsPanel() {
                     <div
                         onClick={(e) => e.stopPropagation()}
                         style={{
-                            width: '520px', maxHeight: '85vh', overflowY: 'auto',
+                            width: '420px',
                             backgroundColor: '#1e1e2e',
                             border: '1px solid rgba(255,255,255,0.12)',
                             borderRadius: '12px',
@@ -2411,168 +2417,17 @@ export function MathsPanel() {
                         }}
                     >
                         <div style={{ marginBottom: '20px' }}>
-                            <div style={{ fontSize: '15px', fontWeight: 700, color: '#fff', marginBottom: '4px' }}>Test Configuration</div>
-                            <div style={{ fontSize: '12px', color: '#888' }}>Configure the simulation parameters for batch-spin execution.</div>
-                        </div>
-
-                        {/* ── Define Inputs ── */}
-                        {simAvailablePorts && simAvailablePorts.inputPorts.length > 0 && (
                             <div style={{
-                                marginBottom: '20px', padding: '16px',
-                                backgroundColor: 'rgba(255,255,255,0.03)',
-                                border: '1px solid rgba(255,255,255,0.08)',
-                                borderRadius: '8px',
-                            }}>
-                                <div style={{
-                                    fontSize: '11px', color: '#a0a0b0', textTransform: 'uppercase' as const,
-                                    letterSpacing: '0.5px', marginBottom: '12px', fontWeight: 600,
-                                }}>Input Port Configuration</div>
-                                {simAvailablePorts.inputPorts.map(port => {
-                                    const isSignal = port.type === 'signal' || port.type === 'boolean';
-                                    const cfg = simInputConfig[port.name] || {
-                                        mode: isSignal ? 'trigger' : 'rng',
-                                        value: 0, rngMin: 1, rngMax: 100,
-                                    };
-                                    return (
-                                        <div key={port.name} style={{
-                                            display: 'flex', alignItems: 'center', gap: '10px',
-                                            padding: '10px 0',
-                                            borderBottom: '1px solid rgba(255,255,255,0.05)',
-                                        }}>
-                                            {/* Port name & type */}
-                                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: '120px' }}>
-                                                <div style={{ width: '6px', height: '6px', borderRadius: '50%', backgroundColor: '#60A5FA' }} />
-                                                <span style={{ fontSize: '13px', color: '#fff', fontWeight: 500 }}>{port.name}</span>
-                                                <span style={{
-                                                    fontSize: '10px', color: '#888', backgroundColor: 'rgba(255,255,255,0.08)',
-                                                    padding: '1px 6px', borderRadius: '3px',
-                                                }}>{port.type}</span>
-                                            </div>
-                                            {/* Mode + controls */}
-                                            <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: '8px' }}>
-                                                <select
-                                                    value={cfg.mode}
-                                                    onChange={(e) => updateSimInputConfig(port.name, { mode: e.target.value as InputMode })}
-                                                    style={{
-                                                        padding: '5px 8px', backgroundColor: 'rgba(255,255,255,0.08)',
-                                                        border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
-                                                        color: '#fff', fontSize: '12px', outline: 'none',
-                                                    }}
-                                                >
-                                                    {!isSignal && <option value="rng" style={{ color: '#000' }}>RNG Value</option>}
-                                                    {!isSignal && <option value="fixed" style={{ color: '#000' }}>Fixed</option>}
-                                                    <option value="trigger" style={{ color: '#000' }}>Always trigger / true</option>
-                                                    <option value="off" style={{ color: '#000' }}>Off</option>
-                                                </select>
-                                                {cfg.mode === 'rng' && (
-                                                    <>
-                                                        <span style={{ fontSize: '10px', color: '#888' }}>Min</span>
-                                                        <input type="number" value={cfg.rngMin ?? 1}
-                                                            onChange={(e) => updateSimInputConfig(port.name, { rngMin: Number(e.target.value) || 0 })}
-                                                            style={{
-                                                                width: '60px', padding: '5px 6px', backgroundColor: 'rgba(255,255,255,0.08)',
-                                                                border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
-                                                                color: '#fff', fontSize: '12px', fontFamily: 'monospace', outline: 'none',
-                                                            }}
-                                                        />
-                                                        <span style={{ fontSize: '10px', color: '#888' }}>Max</span>
-                                                        <input type="number" value={cfg.rngMax ?? 100}
-                                                            onChange={(e) => updateSimInputConfig(port.name, { rngMax: Number(e.target.value) || 0 })}
-                                                            style={{
-                                                                width: '60px', padding: '5px 6px', backgroundColor: 'rgba(255,255,255,0.08)',
-                                                                border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
-                                                                color: '#fff', fontSize: '12px', fontFamily: 'monospace', outline: 'none',
-                                                            }}
-                                                        />
-                                                    </>
-                                                )}
-                                                {cfg.mode === 'fixed' && (
-                                                    <input type="number" value={cfg.value}
-                                                        onChange={(e) => updateSimInputConfig(port.name, { value: Number(e.target.value) || 0 })}
-                                                        style={{
-                                                            width: '80px', padding: '5px 6px', backgroundColor: 'rgba(255,255,255,0.08)',
-                                                            border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
-                                                            color: '#fff', fontSize: '12px', fontFamily: 'monospace', outline: 'none',
-                                                        }}
-                                                    />
-                                                )}
-                                            </div>
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        )}
-
-                        {/* ── RTP Port Mapping ── */}
-                        <div style={{
-                            marginBottom: '20px', padding: '16px',
-                            backgroundColor: 'rgba(255,255,255,0.03)',
-                            border: '1px solid rgba(255,255,255,0.08)',
-                            borderRadius: '8px',
-                        }}>
-                            <div style={{
-                                fontSize: '11px', color: '#a0a0b0', textTransform: 'uppercase' as const,
-                                letterSpacing: '0.5px', marginBottom: '4px', fontWeight: 600,
-                            }}>RTP</div>
-                            <div style={{ fontSize: '11px', color: '#666', marginBottom: '12px' }}>
-                                Map which port carries the bet amount and which carries the win amount for RTP calculation.
-                            </div>
-                            <div style={{ display: 'flex', gap: '12px' }}>
-                                <div style={{ flex: 1 }}>
-                                    <label style={{ display: 'block', fontSize: '10px', color: '#888', marginBottom: '4px' }}>Bet Input</label>
-                                    {simAvailablePorts ? (
-                                        <select value={simBetPort} onChange={(e) => setSimBetPort(e.target.value)}
-                                            style={{
-                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
-                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
-                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
-                                            }}
-                                        >
-                                            <option value="" style={{ color: '#000' }}>— Select input port —</option>
-                                            {simAvailablePorts.inputPorts.map(p => (
-                                                <option key={p.name} value={p.name} style={{ color: '#000' }}>{p.name} ({p.type})</option>
-                                            ))}
-                                        </select>
-                                    ) : (
-                                        <input type="text" value={simBetPort} onChange={(e) => setSimBetPort(e.target.value)}
-                                            style={{
-                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
-                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
-                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
-                                            }}
-                                        />
-                                    )}
-                                </div>
-                                <div style={{ flex: 1 }}>
-                                    <label style={{ display: 'block', fontSize: '10px', color: '#888', marginBottom: '4px' }}>Win Output</label>
-                                    {simAvailablePorts ? (
-                                        <select value={simWinPort} onChange={(e) => setSimWinPort(e.target.value)}
-                                            style={{
-                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
-                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
-                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
-                                            }}
-                                        >
-                                            <option value="" style={{ color: '#000' }}>— Select output port —</option>
-                                            {simAvailablePorts.outputPorts.map(p => (
-                                                <option key={p.name} value={p.name} style={{ color: '#000' }}>{p.name} ({p.type})</option>
-                                            ))}
-                                        </select>
-                                    ) : (
-                                        <input type="text" value={simWinPort} onChange={(e) => setSimWinPort(e.target.value)}
-                                            style={{
-                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
-                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
-                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
-                                            }}
-                                        />
-                                    )}
-                                </div>
+                                fontSize: '15px', fontWeight: 700, color: '#fff',
+                                marginBottom: '4px',
+                            }}>Test Configuration</div>
+                            <div style={{ fontSize: '12px', color: '#888' }}>
+                                Configure the simulation before uploading. The math will be automatically tested, approved, and deployed.
                             </div>
                         </div>
 
                         {/* Simulation Count */}
-                        <div style={{ marginBottom: '24px' }}>
+                        <div style={{ marginBottom: '16px' }}>
                             <label style={{
                                 display: 'block', fontSize: '11px', color: '#a0a0b0',
                                 textTransform: 'uppercase' as const, letterSpacing: '0.5px',
@@ -2580,21 +2435,25 @@ export function MathsPanel() {
                             }}>Simulation Count</label>
                             <input
                                 type="number"
-                                min={1}
+                                min={1000}
                                 max={1000000}
                                 value={simCount}
-                                onChange={(e) => setSimCount(Math.max(1, Math.min(1000000, Number(e.target.value) || 1)))}
+                                onChange={(e) => setSimCount(Math.max(1000, Math.min(1000000, Number(e.target.value) || 10000)))}
                                 style={{
-                                    width: '100%', padding: '10px 12px',
+                                    width: '100%',
+                                    padding: '10px 12px',
                                     backgroundColor: 'rgba(255,255,255,0.06)',
                                     border: '1px solid rgba(255,255,255,0.12)',
-                                    borderRadius: '6px', color: '#fff',
-                                    fontSize: '14px', fontFamily: 'monospace',
-                                    outline: 'none', boxSizing: 'border-box' as const,
+                                    borderRadius: '6px',
+                                    color: '#fff',
+                                    fontSize: '14px',
+                                    fontFamily: 'monospace',
+                                    outline: 'none',
+                                    boxSizing: 'border-box' as const,
                                 }}
                             />
                             <div style={{ fontSize: '10px', color: '#666', marginTop: '4px' }}>
-                                1 – 1,000,000 spins
+                                1,000 – 1,000,000 spins
                             </div>
                         </div>
 
@@ -2628,29 +2487,10 @@ export function MathsPanel() {
                             ))}
                         </div>
 
-                        <div style={{ marginBottom: '16px' }}>
-                            <label style={MODAL_LABEL_STYLE}>Commit message</label>
-                            <input
-                                type="text"
-                                placeholder="what changed, and why"
-                                value={commitPrompt.message}
-                                onChange={(e) => setCommitPrompt({ message: e.target.value })}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter' && commitPrompt.message.trim() && !deployingComponents) {
-                                        const message = commitPrompt.message.trim();
-                                        setCommitPrompt(null);
-                                        void handleDeployMathsComponents(message);
-                                    }
-                                }}
-                                style={MODAL_INPUT_STYLE}
-                                autoFocus
-                            />
-                        </div>
-
+                        {/* Actions */}
                         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
                             <button
-                                onClick={() => setCommitPrompt(null)}
-                                disabled={deployingComponents}
+                                onClick={() => setShowTestConfigModal(false)}
                                 style={{
                                     padding: '8px 16px',
                                     borderRadius: '6px',

--- a/packages/xgenia-editor/src/main/src/autoupdater.js
+++ b/packages/xgenia-editor/src/main/src/autoupdater.js
@@ -1,8 +1,11 @@
 const { dialog, ipcMain } = require('electron');
 const log = require('electron-log/main');
 const { autoUpdater } = require('electron-updater');
+const ProgressBar = require('electron-progressbar');
 
 function setupAutoUpdate(window) {
+
+
   if (process.env.autoUpdate === 'no') return;
 
   if (process.platform === 'linux') {
@@ -14,15 +17,33 @@ function setupAutoUpdate(window) {
 
   autoUpdater.logger.transports.file.level = 'info';
 
+  //Set autodownload to false (prevents the update from being downloaded automatically)
   autoUpdater.autoDownload = false;
 
-  let isDownloading = false;
 
-  const setProgress = (value) => {
-    if (window && !window.isDestroyed()) {
-      window.setProgressBar(value);
-    }
+  let progressBar;
+  const createProgressBar = () => {
+    if (progressBar) return progressBar;
+    progressBar = new ProgressBar({
+      text: 'Preparing data...',
+      detail: 'Wait...',
+      abortOnError: true,
+      closeOnComplete: false,
+      browserWindow: {
+        alwaysOnTop: true
+      }
+    });
+    progressBar
+      .on('completed', function () {
+        progressBar.detail = 'Updates has been downloaded. We are preparing your install.';
+      })
+      .on('progress', function (value) {
+        progressBar.detail = `Value ${value} out of ${progressBar.getOptions().maxValue}...`;
+      });
+    return progressBar;
   };
+
+  let isDownloading = false;
 
   function _checkForUpdates() {
     autoUpdater.checkForUpdates().catch((err) => {
@@ -30,13 +51,6 @@ function setupAutoUpdate(window) {
     });
   }
   _checkForUpdates();
-
-  if (process.env.TEST_UPDATE_FLOW === 'true') {
-    setTimeout(() => {
-      logger.info('[TEST] Simulating update-available');
-      autoUpdater.emit('update-available', { version: '999.0.0' });
-    }, 2000);
-  }
 
   autoUpdater.on('update-available', (event) => {
     logger.info('Update available: ' + event.version);
@@ -50,32 +64,16 @@ function setupAutoUpdate(window) {
       .then((res) => {
         if (res.response === 0) {
           isDownloading = true;
-          setProgress(0);
-
-          if (process.env.TEST_UPDATE_FLOW === 'true') {
-            let percent = 0;
-            const interval = setInterval(() => {
-              percent += 5;
-              autoUpdater.emit('download-progress', {
-                percent,
-                transferred: Math.round((percent / 100) * 20000000),
-                total: 20000000,
-                bytesPerSecond: 1000000
-              });
-              if (percent >= 100) {
-                clearInterval(interval);
-                logger.info('[TEST] Simulating update-downloaded');
-                autoUpdater.emit('update-downloaded');
-              }
-            }, 300);
-          } else {
-            autoUpdater.downloadUpdate().catch((err) => {
-              isDownloading = false;
-              setProgress(-1);
-              dialog.showErrorBox('Download Error', 'Failed to download update: ' + err.message);
-              logger.error('There has been an error downloading the update: ' + err);
-            });
-          }
+          createProgressBar();
+          autoUpdater.downloadUpdate().catch((err) => {
+            isDownloading = false;
+            dialog.showErrorBox('Download Error', 'Failed to download update: ' + err.message);
+            logger.error('There has been an error downloading the update: ' + err);
+            if (progressBar) {
+              progressBar.close();
+              progressBar = undefined;
+            }
+          });
         } else {
           logger.info('User chose to skip the update.');
         }
@@ -83,11 +81,10 @@ function setupAutoUpdate(window) {
   });
 
   autoUpdater.on('download-progress', (progressBarObj) => {
-    const percent = Number(progressBarObj?.percent);
-    if (Number.isFinite(percent)) {
-      setProgress(percent / 100);
-      logger.info(`Download progress: ${percent.toFixed(1)}%`);
+    if (!progressBar) {
+      createProgressBar();
     }
+    progressBar.value = progressBarObj.percent;
   });
 
   autoUpdater.on('error', (err) => {
@@ -96,13 +93,19 @@ function setupAutoUpdate(window) {
     }
     logger.error('Auto-updater error: ' + err.message);
     isDownloading = false;
-    setProgress(-1);
+    if (progressBar) {
+      progressBar.close();
+      progressBar = undefined;
+    }
   });
 
   autoUpdater.on('update-downloaded', () => {
     isDownloading = false;
-    setProgress(-1);
     logger.info('Update downloaded');
+    if (progressBar) {
+      progressBar.close();
+      progressBar = undefined;
+    }
     dialog
       .showMessageBox({
         type: 'info',
@@ -123,23 +126,22 @@ function setupAutoUpdate(window) {
     }
   });
 
+  autoUpdater.addListener("error", (error) => {
+    console.log('Auto update error', error);
+  });
+
   autoUpdater.addListener('update-not-available', () => {
-    setTimeout(
-      () => {
-        _checkForUpdates();
-      },
-      12 * 60 * 60 * 1000
-    );
+    setTimeout(() => {
+      _checkForUpdates();
+    }, 12 * 60 * 60 * 1000); // Check every 12 hours
   });
 
   autoUpdater.addListener('error', (event) => {
+    // There was an error while trying to update, try again
     console.log('Error while auto updating, trying again in a while...');
-    setTimeout(
-      () => {
-        _checkForUpdates();
-      },
-      12 * 60 * 60 * 1000
-    );
+    setTimeout(() => {
+      _checkForUpdates();
+    }, 12 * 60 * 60 * 1000); // Check every 12 hours
   });
 }
 

--- a/packages/xgenia-platform-electron/src/platform-electron.ts
+++ b/packages/xgenia-platform-electron/src/platform-electron.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import { app as electronApp } from 'electron';
 import { app as remoteApp } from '@electron/remote';
-import { app as electronApp, shell, clipboard } from 'electron';
+import { shell, clipboard } from 'electron';
 import { addTrailingSlash, IPlatform, PlatformOS } from '@xgenia/platform';
 import { processPlatformToPlatformOS } from '@xgenia/platform-node/src/helper';
 
@@ -91,28 +92,13 @@ export class PlatformElectron implements IPlatform {
   async saveFile(filename: string, data: string, mimeType: string): Promise<void> {
     const { dialog } = require('@electron/remote');
     const fs = require('fs');
-    const path = require('path');
-
-    const ext = path.extname(filename).replace('.', '').toLowerCase();
-    const filters =
-      mimeType.startsWith('video/') || ['mp4', 'mov', 'webm', 'm4v', 'ogg'].includes(ext)
-        ? [
-            { name: 'Videos', extensions: ['mp4', 'mov', 'webm', 'm4v', 'ogg'] },
-            { name: 'All Files', extensions: ['*'] }
-          ]
-        : mimeType.startsWith('audio/') || ['mp3', 'wav', 'ogg', 'm4a'].includes(ext)
-          ? [
-              { name: 'Audio', extensions: ['mp3', 'wav', 'ogg', 'm4a'] },
-              { name: 'All Files', extensions: ['*'] }
-            ]
-          : [
-              { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'svg'] },
-              { name: 'All Files', extensions: ['*'] }
-            ];
 
     const result = await dialog.showSaveDialog({
       defaultPath: filename,
-      filters
+      filters: [
+        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'svg'] },
+        { name: 'All Files', extensions: ['*'] }
+      ]
     });
 
     if (!result.canceled && result.filePath) {

--- a/scripts/build-pack.ts
+++ b/scripts/build-pack.ts
@@ -52,7 +52,6 @@ const regexList: RegExp[] = [
 
   /* MacOS */
   /.*\.dmg$/,
-  /.*\.zip$/,
   /.*\.blockmap$/,
 
   /* Linux */


### PR DESCRIPTION
## What happened

Merge commit 952bf91 (`Merge branch 'develop' into AICleanup_Fix_2`, Aug 22) merged the stale June state of `develop` into this much-newer branch. The auto-resolution spliced June-era hunks into the middle of current code, leaving **41 TypeScript parse errors** (TS1005/TS1003/TS1128 — unbalanced braces) in:

- `packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts`
- `packages/xgenia-editor/src/editor/src/views/panels/MathsPanel/MathsPanel.tsx`
- `packages/xgenia-editor/src/editor/src/views/EditorTopbar/html-translator.ts`

The renderer bundle failed to emit, so the editor launched to a **black screen** (empty `#root`). The merge also regressed `packages/xgenia-editor/package.json`: dropped the `--no-sandbox` flag from `start:_dev` (breaks dev launch on Linux with AppArmor userns restrictions), removed the `check:assets`/`build:renderer` scripts used by the nightly pipeline, and removed the `prettier` dependency.

## The fix

`git revert -m 1 952bf91`. The resulting tree is **byte-identical to pre-merge 27d603c** (`git diff` is empty), which was verified locally: renderer compiles with 0 errors, editor renders the Projects view end-to-end.

## Note for later

Because the merge itself stays in history, git now considers `develop` (through e5e7719) merged. To genuinely bring those June changes in later, revert this revert or re-apply the changes individually — a plain `git merge develop` will silently skip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)