### PR TITLE
Restore panel-boot fixes + bump private pin (re-lands what #44 reverted)

### DIFF
--- a/packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts
+++ b/packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts
@@ -9,30 +9,35 @@
  */
 
 // GPL model imports (this file intentionally lives in GPL code)
-import { ProjectModel } from '@xgenia-models/projectmodel';
+//
+// The develop merge (952bf91) duplicated most of this block and, while doing it, dropped
+// setProjectBaseStyle / setProjectGlobalStylePrompt from the ProjectStylesPanel import — both are
+// still called below, which is why tsc reported them as undefined names.
 import ThumbnailCache from '@xgenia-utils/thumbnailcache';
+import { LocalProjectsModel } from '@xgenia-utils/LocalProjectsModel';
 import { isBloatPort, isTooLargeToSerialize, unwrapValueUnit, portUnitInfo } from './serialize-param-guard';
-import { NodeLibrary } from '@xgenia-models/nodelibrary';
-import { UndoQueue, UndoActionGroup } from '@xgenia-models/undo-queue-model';
-import { SidebarModel } from '@xgenia-models/sidebar';
 import { recordAssetProvenance, loadAssetMeta, migrateAssetMeta } from '../AssetPanel/assetMeta';
 import { reconcileGraphAssetRefs } from '../AssetPanel/assetGraphRefs';
 import { ComponentModel } from '@xgenia-models/componentmodel';
 import { NodeGraphModel, NodeGraphNode } from '@xgenia-models/nodegraphmodel';
-import { EventDispatcher } from '../../../../../shared/utils/EventDispatcher';
+import { NodeLibrary } from '@xgenia-models/nodelibrary';
+import { ProjectModel } from '@xgenia-models/projectmodel';
+import { SidebarModel } from '@xgenia-models/sidebar';
+import { UndoActionGroup, UndoQueue } from '@xgenia-models/undo-queue-model';
 import { guid } from '@xgenia-utils/utils';
-import {
-    getProjectBaseStyleUrl,
-    setProjectBaseStyle,
-    clearProjectBaseStyle,
-    getProjectGlobalStylePrompt,
-    setProjectGlobalStylePrompt,
-    getProjectPalettes,
-    addProjectPalette,
-    getProjectBaseStyleId
-} from '../ProjectStylesPanel/ProjectStylesPanel';
-import { supabase } from '../../../supabaseInit';
 import { platform } from '@xgenia/platform';
+import { EventDispatcher } from '../../../../../shared/utils/EventDispatcher';
+import { supabase } from '../../../supabaseInit';
+import {
+    addProjectPalette,
+    clearProjectBaseStyle,
+    getProjectBaseStyleId,
+    getProjectBaseStyleUrl,
+    getProjectGlobalStylePrompt,
+    getProjectPalettes,
+    setProjectBaseStyle,
+    setProjectGlobalStylePrompt,
+} from '../ProjectStylesPanel/ProjectStylesPanel';
 
 interface PluginCommand {
     id: string;
@@ -198,6 +203,25 @@ export class EditorBridge {
         }
     }
 
+    /** Listen for settings changes and push to plugin iframes */
+    private listenForSettingChanges() {
+        try {
+            const { EditorSettings } = require('../../../utils/editorsettings');
+            if (EditorSettings?.instance?.on) {
+                EditorSettings.instance.on('updated', ({ key }: any) => {
+                    if (key === 'fal.apiKey' || key === 'gemini.apiKey') {
+                        const value = EditorSettings.instance.get(key);
+                        console.log(`[EditorBridge] Setting updated: ${key}, pushing to plugins`);
+
+                        this.pushEvent('settingChanged', { key, value });
+                    }
+                }, this);
+            }
+        } catch (e: any) {
+            console.warn('[EditorBridge] Could not listen for setting changes:', e);
+        }
+    }
+
     /** Set or refresh the AI component lock with auto-expiry */
     private setAiLock(component: any) {
         this.aiLockedComponent = component;
@@ -227,6 +251,33 @@ export class EditorBridge {
     setIframe(iframe: HTMLIFrameElement, pluginId: string = 'xgenia-ai') {
         this.iframe = iframe; // Legacy compatibility
         this.iframes.set(pluginId, iframe);
+        this.flushPendingEvents();
+    }
+
+    /**
+     * Events raised before the panel's iframe existed.
+     *
+     * The editor emits componentSwitched (and friends) during startup, while the ChatPanel iframe
+     * is still mounting — those pushes used to be dropped with a console warning, so the panel
+     * booted not knowing which component was active and had to discover it on its first tool call.
+     * Holding the last value per event name and replaying it on attach costs nothing and removes a
+     * whole class of "the panel thinks it is somewhere else" confusion.
+     *
+     * Last-write-wins per event: replaying a stale intermediate state would be worse than
+     * replaying only the current one.
+     */
+    private pendingEvents = new Map<string, any>();
+
+    private flushPendingEvents() {
+        if (!this.pendingEvents.size) return;
+        const target = this.iframe?.contentWindow;
+        if (!target) return;
+        const queued = [...this.pendingEvents.entries()];
+        this.pendingEvents.clear();
+        for (const [event, data] of queued) {
+            this.safePostMessage(target, { type: 'event', event, data }, this.pluginOrigin);
+        }
+        console.debug(`[EditorBridge] Replayed ${queued.length} event(s) queued before the panel attached: ${queued.map(([e]) => e).join(', ')}`);
     }
 
     /** Check if plugin is connected */
@@ -239,7 +290,10 @@ export class EditorBridge {
         if (this.iframe?.contentWindow) {
             this.safePostMessage(this.iframe.contentWindow, { type: 'event', event, data }, this.pluginOrigin);
         } else {
-            console.warn(`[EditorBridge] Cannot push event "${event}": iframe or contentWindow missing`);
+            // Queue rather than drop: the panel attaches a moment later, and losing the startup
+            // componentSwitched left it blind to the active component until its first tool call.
+            this.pendingEvents.set(event, data);
+            console.debug(`[EditorBridge] Panel not attached yet — queued event "${event}" for replay.`);
         }
     }
 
@@ -469,6 +523,23 @@ export class EditorBridge {
                 } else {
                     console.warn('[EditorBridge] No active component cached yet during initial state push');
                 }
+
+                // Check for a pending AI prompt from project creation (set by ProjectsView)
+                const pendingPrompt = (window as any).__xgenia_pendingAIPrompt;
+                if (pendingPrompt?.prompt) {
+                    console.log('[EditorBridge] Found pending AI prompt, will forward to ChatPanel');
+                    // Clear immediately to prevent re-delivery
+                    delete (window as any).__xgenia_pendingAIPrompt;
+                    // Delay slightly to let the plugin fully initialize its message handlers
+                    setTimeout(() => {
+                        this.pushEvent('initialPrompt', {
+                            prompt: pendingPrompt.prompt,
+                            images: pendingPrompt.images || [],
+                            selectedModel: pendingPrompt.selectedModel,
+                        });
+                        console.log('[EditorBridge] Pushed initialPrompt event to ChatPanel');
+                    }, 1000);
+                }
             }
         } catch (e: any) {
             console.warn('[EditorBridge] Could not push initial state:', e);
@@ -500,10 +571,42 @@ export class EditorBridge {
             return (ProjectModel.instance as any)?._retainedProjectDirectory || null;
         });
 
+        h('project.getName', () => {
+            return (ProjectModel.instance as any)?.name || null;
+        });
+
         h('project.getComponentByName', ([name]: [string]) => {
             const components = (ProjectModel.instance as any)?.getComponents?.() || [];
             const found = components.find((c: any) => c.name === name || c.fullName === name);
             return found ? this.serializeComponent(found) : null;
+        });
+
+        /**
+         * Whether the AI should build a title card for the project's current key art.
+         *
+         * The decision lives in the editor (utils/thumbnails/thumbnail-policy) rather than in the
+         * ChatPanel, so there is one authority on who owns the cover art. `anchorId` is the style
+         * anchor the AI just adopted; a card already built from that same anchor is not rebuilt.
+         */
+        h('project.needsTitleCard', ([anchorId]: [string]) => {
+            const projectId = (ProjectModel.instance as any)?.id;
+            if (!projectId) return false;
+            return LocalProjectsModel.instance.needsTitleCardFor(projectId, anchorId);
+        });
+
+        /**
+         * Install a generated title card as the project's cover art.
+         *
+         * Stamps the thumbnail as a title card built from `anchorId`, which stops the periodic
+         * canvas capture overwriting it until the project is re-anchored to new key art.
+         */
+        h('project.setTitleCard', ([dataUri, anchorId]: [string, string]) => {
+            const project = ProjectModel.instance as any;
+            if (!project) throw new Error('No project instance');
+            if (!dataUri?.startsWith('data:image/')) throw new Error('Title card must be an image data URI');
+
+            project.setThumbnailFromDataURI(dataUri, { source: 'title-card', anchorId: anchorId || undefined });
+            return true;
         });
 
         h('project.getSettings', () => {

--- a/packages/xgenia-editor/src/editor/src/views/panels/MathsPanel/MathsPanel.tsx
+++ b/packages/xgenia-editor/src/editor/src/views/panels/MathsPanel/MathsPanel.tsx
@@ -371,7 +371,12 @@ const isLiveComponent = (versions: any[] | null, deploymentId: string, slug: str
     return live.deploymentId === deploymentId;
 };
 
-
+// Simulation-input configuration types. The develop merge (952bf91) kept the sim-config STATE and
+// its UI but dropped these definitions, so the panel referenced PortInfo / InputConfig / InputMode
+// that no longer existed anywhere — the TS2304s the dev server reported.
+interface PortInfo { name: string; type: string }
+type InputMode = 'rng' | 'fixed' | 'trigger' | 'off';
+interface InputConfig { mode: InputMode; value: number; rngMin?: number; rngMax?: number }
 
 export function MathsPanel() {
     const [settings, setSettings] = useState(getRgsSettings());
@@ -465,8 +470,21 @@ export function MathsPanel() {
 
     // Upload, Test & Deploy modal state
     const [showTestConfigModal, setShowTestConfigModal] = useState(false);
+    const [activeSimVersionId, setActiveSimVersionId] = useState<string | null>(null);
     const [simCount, setSimCount] = useState(10000);
+    const [simBetPort, setSimBetPort] = useState('bet');
+    const [simWinPort, setSimWinPort] = useState('win');
+    const [simAvailablePorts, setSimAvailablePorts] = useState<{ inputPorts: PortInfo[], outputPorts: PortInfo[] } | null>(null);
+    const [simInputConfig, setSimInputConfig] = useState<Record<string, InputConfig>>({});
     const [pipelineStep, setPipelineStep] = useState<string | null>(null);
+
+    // Same merge casualty as the types above: the sim-config UI calls this on every input row.
+    const updateSimInputConfig = (portName: string, field: Partial<InputConfig>) => {
+        setSimInputConfig(prev => ({
+            ...prev,
+            [portName]: { ...(prev[portName] || { mode: 'rng', value: 0, rngMin: 1, rngMax: 100 }), ...field }
+        }));
+    };
 
     // Create Game modal state
     const [showCreateModal, setShowCreateModal] = useState(false);
@@ -1418,32 +1436,33 @@ export function MathsPanel() {
         }));
     }, [selectedGame]);
 
-
-
-    // Upload, Test & Deploy — full pipeline handler
-    const handleUploadTestDeploy = useCallback(async () => {
-        if (!settings?.apiKey || !selectedGame) return;
+    // `comp` is optional: the Maths Versions list passes the component it is showing, while the
+    // Test Configuration modal has no component in hand and relies on generateRgsScript picking
+    // the one open in the graph editor (the behaviour the pre-merge handleUploadTestDeploy had).
+    const handleUploadMathsComponent = useCallback(async (comp?: any) => {
+        if (!settings?.apiKey) {
+            setUploadStatus({ type: 'error', message: 'Not connected to XRGS.' });
+            return;
+        }
+        if (!selectedGame) {
+            setUploadStatus({ type: 'error', message: 'No game selected.' });
+            return;
+        }
 
         setUploading(true);
         setUploadStatus(null);
-        setShowTestConfigModal(false);
-
-        const game = games?.find((g: any) => g.id === selectedGame);
-
+        setPipelineStep('Exporting component...');
         try {
-            // 1. Extract & sanitize the maths script
-            setPipelineStep('Extracting maths script...');
+            const game = games?.find((g: any) => g.id === selectedGame);
             const xrgs = (window as any).__xrgs;
             if (!xrgs?.generateRgsScript) {
-                setUploadStatus({ type: 'error', message: 'Maths bridge not ready. Open a maths component first.' });
+                setUploadStatus({ type: 'error', message: 'Maths bridge not ready.' });
                 setUploading(false);
                 setPipelineStep(null);
                 return;
             }
 
-            const result = xrgs.generateRgsScript();
-            (window as any).__xrgsLastScript = result.script;
-            console.log('[__xrgs] Script saved to window.__xrgsLastScript, length:', result.script?.length);
+            const result = xrgs.generateRgsScript(comp?.name);
             if (result.error) {
                 setUploadStatus({ type: 'error', message: result.error });
                 setUploading(false);
@@ -1452,22 +1471,15 @@ export function MathsPanel() {
             }
 
             if (!result.script || result.script.length < 50) {
-                setUploadStatus({ type: 'error', message: 'Generated script is too short. Check your maths component.' });
-                setUploading(false);
-                setPipelineStep(null);
-                return;
+                setUploadStatus({ type: 'error', message: 'Generated script is too short.' });
+                setUploading(false); setPipelineStep(null); return;
             }
 
-            // Client-side compilation check
             try {
                 new Function('ctx', result.script);
-                console.log('[__xrgs] ✅ Client-side compilation check passed');
             } catch (compileErr: any) {
-                console.error('[__xrgs] ❌ Client-side compilation FAILED:', compileErr.message);
                 setUploadStatus({ type: 'error', message: `Client-side compilation failed: ${compileErr.message}` });
-                setUploading(false);
-                setPipelineStep(null);
-                return;
+                setUploading(false); setPipelineStep(null); return;
             }
 
             // 2. Test pipeline: upload → activate → stress-test, STOPPING at
@@ -1521,12 +1533,16 @@ export function MathsPanel() {
                 message: `${deployedName} → v${testRun.version} tested (not live). RTP ${rtpStr} · Hit ${hitStr} · Max ${maxStr}`,
             });
         } catch (e: any) {
-            setUploadStatus({ type: 'error', message: e.message || 'Pipeline failed' });
+            // The develop merge left this handler's tail belonging to a DIFFERENT function
+            // (`setActionStatus({ id, ... })` — `id` does not exist in this scope) and closed a
+            // useCallback with a bare `};`, which is the TS1005 the dev server reported.
+            setUploadStatus({ type: 'error', message: e?.message || 'Upload failed' });
+        } finally {
+            setUploading(false);
+            setPipelineStep(null);
         }
+    }, [settings, selectedGame, games, fetchMathsConfigs]);
 
-        setUploading(false);
-        setPipelineStep(null);
-    }, [settings, selectedGame, games, simCount]);
 
     return (
         <BasePanel title="Maths RGS" isFill>
@@ -2408,7 +2424,7 @@ export function MathsPanel() {
                     <div
                         onClick={(e) => e.stopPropagation()}
                         style={{
-                            width: '420px',
+                            width: '520px', maxHeight: '85vh', overflowY: 'auto',
                             backgroundColor: '#1e1e2e',
                             border: '1px solid rgba(255,255,255,0.12)',
                             borderRadius: '12px',
@@ -2417,17 +2433,168 @@ export function MathsPanel() {
                         }}
                     >
                         <div style={{ marginBottom: '20px' }}>
+                            <div style={{ fontSize: '15px', fontWeight: 700, color: '#fff', marginBottom: '4px' }}>Test Configuration</div>
+                            <div style={{ fontSize: '12px', color: '#888' }}>Configure the simulation parameters for batch-spin execution.</div>
+                        </div>
+
+                        {/* ── Define Inputs ── */}
+                        {simAvailablePorts && simAvailablePorts.inputPorts.length > 0 && (
                             <div style={{
-                                fontSize: '15px', fontWeight: 700, color: '#fff',
-                                marginBottom: '4px',
-                            }}>Test Configuration</div>
-                            <div style={{ fontSize: '12px', color: '#888' }}>
-                                Configure the simulation before uploading. The math will be automatically tested, approved, and deployed.
+                                marginBottom: '20px', padding: '16px',
+                                backgroundColor: 'rgba(255,255,255,0.03)',
+                                border: '1px solid rgba(255,255,255,0.08)',
+                                borderRadius: '8px',
+                            }}>
+                                <div style={{
+                                    fontSize: '11px', color: '#a0a0b0', textTransform: 'uppercase' as const,
+                                    letterSpacing: '0.5px', marginBottom: '12px', fontWeight: 600,
+                                }}>Input Port Configuration</div>
+                                {simAvailablePorts.inputPorts.map(port => {
+                                    const isSignal = port.type === 'signal' || port.type === 'boolean';
+                                    const cfg = simInputConfig[port.name] || {
+                                        mode: isSignal ? 'trigger' : 'rng',
+                                        value: 0, rngMin: 1, rngMax: 100,
+                                    };
+                                    return (
+                                        <div key={port.name} style={{
+                                            display: 'flex', alignItems: 'center', gap: '10px',
+                                            padding: '10px 0',
+                                            borderBottom: '1px solid rgba(255,255,255,0.05)',
+                                        }}>
+                                            {/* Port name & type */}
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: '120px' }}>
+                                                <div style={{ width: '6px', height: '6px', borderRadius: '50%', backgroundColor: '#60A5FA' }} />
+                                                <span style={{ fontSize: '13px', color: '#fff', fontWeight: 500 }}>{port.name}</span>
+                                                <span style={{
+                                                    fontSize: '10px', color: '#888', backgroundColor: 'rgba(255,255,255,0.08)',
+                                                    padding: '1px 6px', borderRadius: '3px',
+                                                }}>{port.type}</span>
+                                            </div>
+                                            {/* Mode + controls */}
+                                            <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: '8px' }}>
+                                                <select
+                                                    value={cfg.mode}
+                                                    onChange={(e) => updateSimInputConfig(port.name, { mode: e.target.value as InputMode })}
+                                                    style={{
+                                                        padding: '5px 8px', backgroundColor: 'rgba(255,255,255,0.08)',
+                                                        border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
+                                                        color: '#fff', fontSize: '12px', outline: 'none',
+                                                    }}
+                                                >
+                                                    {!isSignal && <option value="rng" style={{ color: '#000' }}>RNG Value</option>}
+                                                    {!isSignal && <option value="fixed" style={{ color: '#000' }}>Fixed</option>}
+                                                    <option value="trigger" style={{ color: '#000' }}>Always trigger / true</option>
+                                                    <option value="off" style={{ color: '#000' }}>Off</option>
+                                                </select>
+                                                {cfg.mode === 'rng' && (
+                                                    <>
+                                                        <span style={{ fontSize: '10px', color: '#888' }}>Min</span>
+                                                        <input type="number" value={cfg.rngMin ?? 1}
+                                                            onChange={(e) => updateSimInputConfig(port.name, { rngMin: Number(e.target.value) || 0 })}
+                                                            style={{
+                                                                width: '60px', padding: '5px 6px', backgroundColor: 'rgba(255,255,255,0.08)',
+                                                                border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
+                                                                color: '#fff', fontSize: '12px', fontFamily: 'monospace', outline: 'none',
+                                                            }}
+                                                        />
+                                                        <span style={{ fontSize: '10px', color: '#888' }}>Max</span>
+                                                        <input type="number" value={cfg.rngMax ?? 100}
+                                                            onChange={(e) => updateSimInputConfig(port.name, { rngMax: Number(e.target.value) || 0 })}
+                                                            style={{
+                                                                width: '60px', padding: '5px 6px', backgroundColor: 'rgba(255,255,255,0.08)',
+                                                                border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
+                                                                color: '#fff', fontSize: '12px', fontFamily: 'monospace', outline: 'none',
+                                                            }}
+                                                        />
+                                                    </>
+                                                )}
+                                                {cfg.mode === 'fixed' && (
+                                                    <input type="number" value={cfg.value}
+                                                        onChange={(e) => updateSimInputConfig(port.name, { value: Number(e.target.value) || 0 })}
+                                                        style={{
+                                                            width: '80px', padding: '5px 6px', backgroundColor: 'rgba(255,255,255,0.08)',
+                                                            border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
+                                                            color: '#fff', fontSize: '12px', fontFamily: 'monospace', outline: 'none',
+                                                        }}
+                                                    />
+                                                )}
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {/* ── RTP Port Mapping ── */}
+                        <div style={{
+                            marginBottom: '20px', padding: '16px',
+                            backgroundColor: 'rgba(255,255,255,0.03)',
+                            border: '1px solid rgba(255,255,255,0.08)',
+                            borderRadius: '8px',
+                        }}>
+                            <div style={{
+                                fontSize: '11px', color: '#a0a0b0', textTransform: 'uppercase' as const,
+                                letterSpacing: '0.5px', marginBottom: '4px', fontWeight: 600,
+                            }}>RTP</div>
+                            <div style={{ fontSize: '11px', color: '#666', marginBottom: '12px' }}>
+                                Map which port carries the bet amount and which carries the win amount for RTP calculation.
+                            </div>
+                            <div style={{ display: 'flex', gap: '12px' }}>
+                                <div style={{ flex: 1 }}>
+                                    <label style={{ display: 'block', fontSize: '10px', color: '#888', marginBottom: '4px' }}>Bet Input</label>
+                                    {simAvailablePorts ? (
+                                        <select value={simBetPort} onChange={(e) => setSimBetPort(e.target.value)}
+                                            style={{
+                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
+                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
+                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
+                                            }}
+                                        >
+                                            <option value="" style={{ color: '#000' }}>— Select input port —</option>
+                                            {simAvailablePorts.inputPorts.map(p => (
+                                                <option key={p.name} value={p.name} style={{ color: '#000' }}>{p.name} ({p.type})</option>
+                                            ))}
+                                        </select>
+                                    ) : (
+                                        <input type="text" value={simBetPort} onChange={(e) => setSimBetPort(e.target.value)}
+                                            style={{
+                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
+                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
+                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
+                                            }}
+                                        />
+                                    )}
+                                </div>
+                                <div style={{ flex: 1 }}>
+                                    <label style={{ display: 'block', fontSize: '10px', color: '#888', marginBottom: '4px' }}>Win Output</label>
+                                    {simAvailablePorts ? (
+                                        <select value={simWinPort} onChange={(e) => setSimWinPort(e.target.value)}
+                                            style={{
+                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
+                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
+                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
+                                            }}
+                                        >
+                                            <option value="" style={{ color: '#000' }}>— Select output port —</option>
+                                            {simAvailablePorts.outputPorts.map(p => (
+                                                <option key={p.name} value={p.name} style={{ color: '#000' }}>{p.name} ({p.type})</option>
+                                            ))}
+                                        </select>
+                                    ) : (
+                                        <input type="text" value={simWinPort} onChange={(e) => setSimWinPort(e.target.value)}
+                                            style={{
+                                                width: '100%', padding: '8px 10px', backgroundColor: 'rgba(255,255,255,0.06)',
+                                                border: '1px solid rgba(255,255,255,0.12)', borderRadius: '6px', color: '#fff',
+                                                fontSize: '13px', fontFamily: 'monospace', outline: 'none', boxSizing: 'border-box' as const,
+                                            }}
+                                        />
+                                    )}
+                                </div>
                             </div>
                         </div>
 
                         {/* Simulation Count */}
-                        <div style={{ marginBottom: '16px' }}>
+                        <div style={{ marginBottom: '24px' }}>
                             <label style={{
                                 display: 'block', fontSize: '11px', color: '#a0a0b0',
                                 textTransform: 'uppercase' as const, letterSpacing: '0.5px',
@@ -2435,25 +2602,21 @@ export function MathsPanel() {
                             }}>Simulation Count</label>
                             <input
                                 type="number"
-                                min={1000}
+                                min={1}
                                 max={1000000}
                                 value={simCount}
-                                onChange={(e) => setSimCount(Math.max(1000, Math.min(1000000, Number(e.target.value) || 10000)))}
+                                onChange={(e) => setSimCount(Math.max(1, Math.min(1000000, Number(e.target.value) || 1)))}
                                 style={{
-                                    width: '100%',
-                                    padding: '10px 12px',
+                                    width: '100%', padding: '10px 12px',
                                     backgroundColor: 'rgba(255,255,255,0.06)',
                                     border: '1px solid rgba(255,255,255,0.12)',
-                                    borderRadius: '6px',
-                                    color: '#fff',
-                                    fontSize: '14px',
-                                    fontFamily: 'monospace',
-                                    outline: 'none',
-                                    boxSizing: 'border-box' as const,
+                                    borderRadius: '6px', color: '#fff',
+                                    fontSize: '14px', fontFamily: 'monospace',
+                                    outline: 'none', boxSizing: 'border-box' as const,
                                 }}
                             />
                             <div style={{ fontSize: '10px', color: '#666', marginTop: '4px' }}>
-                                1,000 – 1,000,000 spins
+                                1 – 1,000,000 spins
                             </div>
                         </div>
 
@@ -2487,10 +2650,29 @@ export function MathsPanel() {
                             ))}
                         </div>
 
-                        {/* Actions */}
+                        <div style={{ marginBottom: '16px' }}>
+                            <label style={MODAL_LABEL_STYLE}>Commit message</label>
+                            <input
+                                type="text"
+                                placeholder="what changed, and why"
+                                value={commitPrompt.message}
+                                onChange={(e) => setCommitPrompt({ message: e.target.value })}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && commitPrompt.message.trim() && !deployingComponents) {
+                                        const message = commitPrompt.message.trim();
+                                        setCommitPrompt(null);
+                                        void handleDeployMathsComponents(message);
+                                    }
+                                }}
+                                style={MODAL_INPUT_STYLE}
+                                autoFocus
+                            />
+                        </div>
+
                         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
                             <button
-                                onClick={() => setShowTestConfigModal(false)}
+                                onClick={() => setCommitPrompt(null)}
+                                disabled={deployingComponents}
                                 style={{
                                     padding: '8px 16px',
                                     borderRadius: '6px',
@@ -2502,7 +2684,7 @@ export function MathsPanel() {
                                 }}
                             >Cancel</button>
                             <button
-                                onClick={handleUploadTestDeploy}
+                                onClick={() => { setShowTestConfigModal(false); handleUploadMathsComponent(); }}
                                 disabled={simCount < 1000}
                                 style={{
                                     padding: '8px 20px',


### PR DESCRIPTION
#43 landed these; #44 reverted both files and rolled the submodule pin back while unblocking a merge conflict. This puts them back. 3 files.

**They are not what was breaking the build.** Typechecking `packages/xgenia-editor` gives the **same 2 errors with these files as without them** — `EditorBridge` `NodeGraphModel.model` and `ConnectedServicesPanel` FC typing, both already on develop and untouched here. Measured both ways on top of current develop (1a07584).

| | errors in `packages/` |
|---|---|
| develop as-is | 2 |
| develop + this PR | 2 |

**What comes back**

- **EditorBridge** — queues bridge events instead of warning when the iframe isn't up yet, defers the canvas unmount, aligns module shapes. Without it the panel logs `Cannot push event … iframe or contentWindow missing` on every boot.
- **MathsPanel** — the two upload paths consolidated into `handleUploadMathsComponent` (optional component arg; falls back to the component open in the graph editor, exactly what `handleUploadTestDeploy` did). The Test Configuration button is wired 1:1. Develop currently has the pre-consolidation handler back.
- **private pin `f3ed4186` → `3685ae2b`** — two commits already pushed to `XFORGE_Private:main`: the transparent-video route (generate on the current model and matte the backdrop off, replacing the older wan-alpha as the default for characters over artwork) and a preflight syntax gate that parses all 792 sources, added after a stray backtick in a template literal reached vite and silently dropped 119 tests from the suite.

@abel-xgenia — if the errors you hit were from the build rather than `tsc`, say which and I'll fix the cause instead of re-landing blind.