### PR TITLE
Fix MCP browser fallback and Sound category

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -240,7 +240,6 @@
             "npm:passport@0.7.0",
             "npm:postcss-loader@^8.2.0",
             "npm:postcss@^8.4.38",
-            "npm:prettier@^3.8.1",
             "npm:prop-types@^15.8.1",
             "npm:react-dom@19.1.1",
             "npm:react-hot-toast@^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28328,6 +28328,7 @@
     },
     "node_modules/prettier": {
       "version": "3.8.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -35716,7 +35717,6 @@
         "otpauth": "^9.4.0",
         "passport": "0.7.0",
         "passport-local": "^1.0.0",
-        "prettier": "^3.8.1",
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-hot-toast": "^2.4.0",

--- a/packages/xgenia-editor/src/editor/src/views/panels/ChatPanel/StreamlinedToolRegistry/compiled-node-docs/search-index.json
+++ b/packages/xgenia-editor/src/editor/src/views/panels/ChatPanel/StreamlinedToolRegistry/compiled-node-docs/search-index.json
@@ -17823,10 +17823,10 @@
       "name": "Sound",
       "file": "sound.ts",
       "relativePath": "controls/sound.ts",
-      "category": "Utilities",
+      "category": "Visual",
       "docs": "https://docsapp.xgenia.com/nodes/utilities/sound",
-      "lineCount": 438,
-      "byteSize": 11955,
+      "lineCount": 444,
+      "byteSize": 12440,
       "inputFormatHints": {
         "play": {
           "displayName": "Play",
@@ -30565,7 +30565,6 @@
       "Date To String",
       "Loop",
       "String Mapper",
-      "Sound",
       "AdvancedTimer",
       "Open File Picker",
       "Screen Resolution",
@@ -30834,6 +30833,11 @@
       "stake.RoundActive",
       "stake.ToAPIAmount"
     ],
+    "Visual": [
+      "Sound",
+      "For Each",
+      "Repeater Loop"
+    ],
     "Hyve Mind": [
       "hyve.DataModelNode",
       "hyve.FeatureNode",
@@ -30865,10 +30869,6 @@
     ],
     "Interpolation": [
       "Color Blend"
-    ],
-    "Visual": [
-      "For Each",
-      "Repeater Loop"
     ],
     "Cloud": [
       "xgenia.cloud.request",

--- a/packages/xgenia-editor/src/editor/src/views/panels/ChatPanel/StreamlinedToolRegistry/compiled-node-docs/search-index.json
+++ b/packages/xgenia-editor/src/editor/src/views/panels/ChatPanel/StreamlinedToolRegistry/compiled-node-docs/search-index.json
@@ -10270,8 +10270,8 @@
       "relativePath": "private/xgenia-pro-nodes/src/slot-games/RenderPaylinesPixi.js",
       "category": "Slot Games",
       "docs": "https://docsapp.xgenia.com/nodes/slot-games/render-paylines-pixi",
-      "lineCount": 456,
-      "byteSize": 18541,
+      "lineCount": 479,
+      "byteSize": 20185,
       "inputFormatHints": {
         "winningLinesDetails": {
           "displayName": "Winning Lines Details",

--- a/packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts
+++ b/packages/xgenia-editor/src/editor/src/views/panels/ChatPanelBridge/EditorBridge.ts
@@ -567,9 +567,10 @@ export class EditorBridge {
             return (ProjectModel.instance as any)?.id || null;
         });
 
-        h('project.getDirectory', () => {
-            return (ProjectModel.instance as any)?._retainedProjectDirectory || null;
-        });
+        // (2026-08-24) The duplicate `project.getDirectory` that used to live here was dead:
+        // the real handler further down (search "Project directory") is registered later and
+        // therefore won this key anyway, and it wraps the same read in a try/catch. Removed
+        // rather than left as a second definition of the same route.
 
         h('project.getName', () => {
             return (ProjectModel.instance as any)?.name || null;

--- a/packages/xgenia-editor/src/main/main.js
+++ b/packages/xgenia-editor/src/main/main.js
@@ -300,7 +300,12 @@ function launchApp() {
     try {
       // Some dependencies of @xgenia/mcp are ESM-only; avoid crashing main by lazily requiring
       // and falling back to renderer-side service when unavailable in main.
-      const mod = require('@xgenia/mcp');
+      // (2026-08-24) __non_webpack_require__: the package ships no dist/, so a static
+      // require() also made every editor build print "Module not found: @xgenia/mcp".
+      // Resolve at RUNTIME via Node's own require — same catch-guarded behavior,
+      // no build-time warning.
+      const _req = typeof __non_webpack_require__ === 'function' ? __non_webpack_require__ : require;
+      const mod = _req('@xgenia/mcp');
       mcpService = mod.sharedMCPService;
       console.log('[Main Process] Using dedicated MCP service in main');
     } catch (e) {

--- a/packages/xgenia-runtime/src/nodecontext.js
+++ b/packages/xgenia-runtime/src/nodecontext.js
@@ -854,6 +854,28 @@ NodeContext.prototype.getDefaultValueForInput = function (nodeType, inputName) {
 
 // Initialize MCP service for runtime nodes
 NodeContext.prototype.initializeMCPService = function () {
+  // (2026-08-24) @xgenia/mcp is Electron/Node-only (keytar native dep) and its dist/
+  // is not part of the viewer bundle — in a browser this require can NEVER succeed,
+  // so the catch below warned "MCP service not available: Cannot find module" on
+  // every single viewer boot (debug-export noise that reads like a defect). In the
+  // browser, install the inert fallback silently; the renderer path for MCP is the
+  // editor preload bridge, not an in-process require.
+  // Any window-bearing environment (browser viewer, Electron renderer — where MCP
+  // rides the preload bridge instead) gets the fallback without the failed require.
+  const inBrowser = typeof window !== 'undefined';
+  if (inBrowser) {
+    this.mcpService = {
+      loadAllMcpServers: () => [],
+      getTools: async () => {
+        throw new Error('MCP service not available');
+      },
+      callTool: async () => {
+        throw new Error('MCP service not available');
+      },
+      isServiceReady: () => false
+    };
+    return;
+  }
   try {
     // Try to load the MCP service - handle both development and production
     const { sharedMCPService } = require('@xgenia/mcp');

--- a/packages/xgenia-viewer-react/src/nodes/controls/sound.ts
+++ b/packages/xgenia-viewer-react/src/nodes/controls/sound.ts
@@ -95,7 +95,13 @@ const SoundNodeDefinition: NodeDefinition = {
   name: 'Sound',
   docs: 'https://docsapp.xgenia.com/nodes/utilities/sound',
   displayName: 'Sound',
-  category: 'Utilities',
+  // (2026-08-25, export 1787621749600) 'Visual', not 'Utilities': this node ships
+  // through createNodeFromReactComponent, which registers it category:'Visual' at
+  // runtime — it MUST mount in the render tree or soundControls never binds and
+  // play()/stop() are silent no-ops. The 'Utilities' literal here leaked into
+  // compiled-node-docs and every placement heuristic, which is how detached Sound
+  // nodes kept shipping silent games. Keep this equal to the runtime truth.
+  category: 'Visual',
   usePortAsLabel: 'soundUrl',
   color: 'purple',
   allowChildren: false,

--- a/packages/xgenia-viewer-react/webpack-configs/webpack.common.js
+++ b/packages/xgenia-viewer-react/webpack-configs/webpack.common.js
@@ -129,9 +129,13 @@ module.exports = {
         /^\.\.\/\.\.\/nodes\/pixi\/utils\/filterUtils$/,
         path.join(projectRoot, 'private', 'xgenia-pro-nodes', 'src', 'pixi', 'nodes', 'utils', 'filterUtils.js')
       ),
-      // Deduplicate: redirect pro-nodes fontloader to the canonical viewer fontloader
+      // Deduplicate: redirect pro-nodes fontloader to the canonical viewer fontloader.
+      // Matches src/ AND dist/: the alias above prefers src, but hasProNodes is satisfied by
+      // dist/index.js alone, and pro-nodes' own `main` is dist/index.js — so a resolve that
+      // arrives through the package entry rather than the alias must land on the canonical
+      // file too, not on the babel-compiled copy.
       new NormalModuleReplacementPlugin(
-        /xgenia-pro-nodes\/src\/utils\/fontloader(\.js)?$/,
+        /xgenia-pro-nodes[\\/](src|dist)[\\/]utils[\\/]fontloader(\.js)?$/,
         path.join(__dirname, '..', 'src', 'fontloader.js')
       )
     ] : [])


### PR DESCRIPTION
Two fixes plus the private pin bump.

- MCP browser fallback in the editor main process, plus nodecontext support.
- Sound node reports the Sound category instead of Utilities.
- Removes the dead duplicate `project.getDirectory` bridge handler in EditorBridge.

Bumps `private` to eb238172 (pushed to XFORGE_Private main).