### PR TITLE
Serve correct MIME types for video, audio and font assets

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -549,7 +549,8 @@
             "npm:babel-plugin-module-resolver@^5.0.2",
             "npm:bezier-easing@^2.1.0",
             "npm:mathjs@^14.0.1",
-            "npm:revolt-fx@^1.3.1"
+            "npm:revolt-fx@^1.3.1",
+            "npm:webfontloader@^1.6.28"
           ]
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -41037,9 +41037,11 @@
       "version": "1.0.0",
       "license": "PROPRIETARY",
       "dependencies": {
+        "@xgenia/runtime": "file:../../packages/xgenia-runtime",
         "bezier-easing": "^2.1.0",
         "mathjs": "^14.0.1",
-        "revolt-fx": "^1.3.1"
+        "revolt-fx": "^1.3.1",
+        "webfontloader": "^1.6.28"
       },
       "devDependencies": {
         "@babel/cli": "^7.26.4",

--- a/packages/xgenia-editor/src/editor/src/views/panels/ChatPanel/StreamlinedToolRegistry/compiled-node-docs/search-index.json
+++ b/packages/xgenia-editor/src/editor/src/views/panels/ChatPanel/StreamlinedToolRegistry/compiled-node-docs/search-index.json
@@ -6955,8 +6955,8 @@
       "relativePath": "private/xgenia-pro-nodes/src/pixi/nodes/PixiReelCell.js",
       "category": "Pixi",
       "docs": "https://docsapp.xgenia.com/nodes/graphics/pixi/reel-cell",
-      "lineCount": 769,
-      "byteSize": 32240,
+      "lineCount": 776,
+      "byteSize": 32836,
       "inputFormatHints": {
         "width": {
           "displayName": "Width",
@@ -7157,8 +7157,8 @@
       "relativePath": "private/xgenia-pro-nodes/src/pixi/nodes/PixiReelColumn.js",
       "category": "Pixi",
       "docs": "https://docsapp.xgenia.com/nodes/graphics/pixi/reel-column",
-      "lineCount": 1745,
-      "byteSize": 76494,
+      "lineCount": 1752,
+      "byteSize": 77058,
       "inputFormatHints": {
         "visibleRows": {
           "displayName": "Visible Rows",

--- a/packages/xgenia-editor/src/main/src/web-server.js
+++ b/packages/xgenia-editor/src/main/src/web-server.js
@@ -1100,14 +1100,49 @@ function getContentType(request) {
       contentType = 'image/gif';
       break;
     case '.jpg':
-      contentType = 'image/jpg';
+      contentType = 'image/jpeg';
       break;
+    // (2026-08-27, export 1787803023693) THE MISSING CASES WERE SERVING text/html.
+    // A generated reel-dog-win.webm reached the browser with the right bytes (valid EBML
+    // magic, correct length) and content-type text/html — this switch's default — so the
+    // <video> element fired `error` and every transparent-webm win animation "vanished".
+    // Sessions across three days blamed alpha compositing, hide-latches, and the video
+    // model for what was this switch all along; one session started base64-inlining a
+    // 3MB clip into a node parameter to get around it. Sweep, not a one-extension fix:
+    // every asset family the engine actually loads (video, audio for the Sound node,
+    // fonts now that writes fetch them, modern image formats) gets its real type.
+    // The .wav case also fell through into .mp4 (the eslint-disable was masking it),
+    // so wav files were served as video/mp4.
     case '.wav':
       contentType = 'audio/wav';
-    // eslint-disable-next-line no-fallthrough
+      break;
+    case '.mp3':
+      contentType = 'audio/mpeg';
+      break;
+    case '.ogg':
+      contentType = 'audio/ogg';
+      break;
     case '.mp4':
     case '.m4v':
       contentType = 'video/mp4';
+      break;
+    case '.webm':
+      contentType = 'video/webm';
+      break;
+    case '.jpeg':
+      contentType = 'image/jpeg';
+      break;
+    case '.avif':
+      contentType = 'image/avif';
+      break;
+    case '.woff':
+      contentType = 'font/woff';
+      break;
+    case '.woff2':
+      contentType = 'font/woff2';
+      break;
+    case '.otf':
+      contentType = 'font/otf';
       break;
     case '.wasm':
       contentType = 'application/wasm';


### PR DESCRIPTION
The editor's web server only had cases for a handful of extensions, so everything
else fell through to `text/html`. A generated `.webm` reached the browser with
valid bytes and `content-type: text/html`, the `<video>` element fired `error`,
and every transparent-webm win animation looked like it had vanished. That was
blamed on alpha compositing, hide-latches and the video model across several
sessions before the MIME switch turned out to be the cause.

Fixed as a sweep rather than one extension, covering the asset families the
engine actually loads:

- video: `.webm`
- audio: `.mp3`, `.ogg`, and `.wav`, which was falling through into the `.mp4`
  case and being served as `video/mp4` (an `eslint-disable` comment was hiding
  the missing `break`)
- fonts: `.woff`, `.woff2`, `.otf`, now that writes fetch them
- images: `.jpeg`, `.avif`, and `.jpg` corrected from `image/jpg` to `image/jpeg`

Also brings `package-lock.json` and `deno.lock` up to date with the private
submodule pin already on develop, which added `webfontloader` and the
`@xgenia/runtime` file dependency to `xgenia-pro-nodes`, and regenerates
`search-index.json` for the reel node line counts.

The submodule pin itself is unchanged by this branch.
