### PR TITLE
Fix create-project modal layout

### DIFF
--- a/packages/xgenia-editor/src/editor/src/styles/projectsview.css
+++ b/packages/xgenia-editor/src/editor/src/styles/projectsview.css
@@ -2043,12 +2043,12 @@
 @keyframes popupIn {
   from {
     opacity: 0;
-    transform: translateY(-50%) scale(0.96);
+    transform: scale(0.96);
   }
 
   to {
     opacity: 1;
-    transform: translateY(-50%) scale(1);
+    transform: scale(1);
   }
 }
 

--- a/packages/xgenia-editor/src/editor/src/templates/projectsview.html
+++ b/packages/xgenia-editor/src/editor/src/templates/projectsview.html
@@ -443,8 +443,14 @@
       color: #fff;
     }
 
-    /* Popup and Modal Styles */
+    /* ===== Create-project modal ===== */
     .projects-start-pane-feed-big {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
       background: rgba(0, 0, 0, 0.7) !important;
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
@@ -453,44 +459,187 @@
     }
 
     .create-from-template-popup {
-      background: rgba(22, 22, 24, 0.85) !important;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      width: 720px;
+      max-width: 100%;
+      max-height: 100%;
+      background: rgba(22, 22, 24, 0.92);
       backdrop-filter: blur(40px) saturate(180%);
       -webkit-backdrop-filter: blur(40px) saturate(180%);
-      border: none !important;
-      border-radius: 12px;
-      box-shadow: 0 0 0 0.5px rgba(255, 255, 255, 0.08), 0 25px 50px rgba(0, 0, 0, 0.5);
+      border: none;
+      border-radius: 16px;
+      box-shadow: 0 0 0 0.5px rgba(255, 255, 255, 0.08), 0 24px 48px rgba(0, 0, 0, 0.5);
       overflow: hidden;
-      max-width: 90vw;
-      max-height: 90vh;
-      min-height: 300px !important;
-      min-width: 600px !important;
-      display: block !important;
-      visibility: visible !important;
     }
 
     /* Compact layout for the blank-project flow — no template preview to make room for */
     .create-from-template-popup.blank-project-mode {
-      width: 460px !important;
-      min-width: 460px !important;
-      min-height: 0 !important;
+      width: 440px;
     }
 
-    .create-from-template-popup.blank-project-mode #start-pane-feed-item-big-create-new-project {
-      padding-bottom: 48px;
+    .cnp-close {
+      position: absolute;
+      top: 20px;
+      right: 20px;
+      z-index: 2;
+      cursor: pointer;
     }
 
-    .projects-feed-image-big {
+    .cnp-body {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      gap: 24px;
+      padding: 32px 32px 0 32px;
+      overflow-y: auto;
+    }
+
+    .create-from-template-popup .projects-feed-image-big {
+      display: flex;
+      flex: 0 0 200px;
+      width: 200px;
+      height: 200px;
+      border-radius: 12px;
+      align-items: center;
+      justify-content: center;
       background-color: rgba(255, 255, 255, 0.04);
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
+      color: rgba(255, 255, 255, 0.35);
     }
 
-    .projects-popup-title {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--text-primary);
-      margin-bottom: 0.5rem;
+    .cnp-content {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    /* Room for the close button, so a long template title never runs under it */
+    .cnp-header {
+      padding-right: 40px;
+    }
+
+    .create-from-template-popup .projects-popup-title {
+      font-size: 18px;
+      font-weight: 600;
+      line-height: 1.3;
+      color: rgba(255, 255, 255, 0.9);
+      text-transform: none;
+      margin: 0;
+    }
+
+    .cnp-desc {
+      margin: 6px 0 0;
+      font-size: 13px;
+      line-height: 1.5;
+      color: rgba(255, 255, 255, 0.45);
+    }
+
+    .cnp-desc:empty {
+      display: none;
+    }
+
+    .cnp-field {
+      margin-top: 24px;
+    }
+
+    .cnp-field-label {
+      display: block;
+      margin: 0 0 8px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.45);
+    }
+
+    .cnp-input-wrap {
+      display: flex;
+      align-items: center;
+      height: 40px;
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.06);
+      box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.08);
+      transition: background 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cnp-input-wrap:focus-within {
+      background: rgba(255, 255, 255, 0.09);
+      box-shadow: inset 0 0 0 1px rgba(103, 222, 146, 0.45);
+    }
+
+    .create-from-template-popup .cnp-input {
+      flex: 1 1 auto;
+      width: 100%;
+      min-width: 0;
+      height: 100%;
+      padding: 0 14px;
+      background: transparent;
+      border: none;
+      outline: none;
+      font-size: 14px;
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    .create-from-template-popup .cnp-input::placeholder {
+      color: rgba(255, 255, 255, 0.35);
+    }
+
+    .cnp-footer {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 28px;
+      padding: 20px 32px;
+      border-top: 0.5px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .cnp-cancel {
+      padding: 10px 14px;
+      font-size: 13px;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.45);
+      background: none;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: color 0.2s ease, background 0.2s ease;
+    }
+
+    .cnp-cancel:hover {
+      color: rgba(255, 255, 255, 0.8);
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    /* Primary CTA. The class is shared with the full-width sidebar button, so the modal
+       restates the parts that differ: auto width, no stacking margin, accent fill. */
+    .create-from-template-popup .projects-create-new-project-button {
+      width: auto;
+      margin: 0;
+      padding: 10px 18px;
+      font-size: 13px;
+      font-weight: 600;
+      border: none;
+      background: #67DE92;
+      color: #0b0f0c;
+      white-space: nowrap;
+    }
+
+    .create-from-template-popup .projects-create-new-project-button:hover {
+      background: #79E7A2;
+      color: #0b0f0c;
+    }
+
+    .create-from-template-popup .projects-create-new-project-button:disabled {
+      background: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.35);
+      cursor: default;
+      opacity: 1;
     }
 
     .projects-sublabel {
@@ -1015,47 +1164,39 @@
   </div>
 
   <!-- show selected feed item big -->
-  <div id="start-pane-feed-big" class="projects-start-pane-feed-big"
-    style="position:absolute; top:0px; left:0px; right:0px; bottom:0px; display:none;">
+  <div id="start-pane-feed-big" class="projects-start-pane-feed-big" style="display:none;">
 
-    <div class="create-from-template-popup"
-      style="position:absolute; left: 0; right: 0; top: 50%; transform: translateY(-50%); margin-left: auto; margin-right: auto; width: 700px;">
+    <div class="create-from-template-popup">
 
-      <div style="position:relative; height:100%; display: flex; flex-direction: row;">
-        <div id="start-pane-feed-item-big-image" class="projects-feed-image-big"
-          style="flex-shrink:0; height:250px; width:250px; margin:20px; border-radius: 12px; background-size: cover; background-position: center; background-repeat: no-repeat; display: flex; align-items: center; justify-content: center;">
-        </div>
+      <div class="cnp-close" data-click="onExitBigFeedItemClicked">
+        <div class="projects-exit-big-feed-item-icon"></div>
+      </div>
 
-        <div id="start-pane-feed-item-big-create-new-project" style="margin:20px; flex: 1;">
+      <div class="cnp-body">
+        <div id="start-pane-feed-item-big-image" class="projects-feed-image-big"></div>
 
-          <div style="margin-left:0px; margin-right:20px;">
+        <div id="start-pane-feed-item-big-create-new-project" class="cnp-content">
+
+          <div class="cnp-header">
             <div id="start-pane-feed-item-big-title" class="projects-popup-title">Create new project from template</div>
-            <div class="projects-sublabel" style="margin-top:5px;" data-bind="watch"
-              data-html="projectTemplateLongDesc"></div>
+            <div class="cnp-desc" data-bind="watch" data-html="projectTemplateLongDesc"></div>
           </div>
 
-          <div style="margin-top:20px; margin-bottom:10px;">
-            <div style="margin-bottom:15px;" class="projects-label-small">Project name</div>
-            <div style="display: flex; width:350px; height:35px;" class="projects-search-bg">
-              <input id="create-new-project-from-feed-item-name" type="string" placeholder="Enter project name"
-                class="projects-project-name-input" style="flex-grow: 1; width:100%;"
-                data-test="new-project-name-input"></input>
+          <div class="cnp-field">
+            <label class="cnp-field-label" for="create-new-project-from-feed-item-name">Project name</label>
+            <div class="cnp-input-wrap">
+              <input id="create-new-project-from-feed-item-name" type="text" placeholder="Enter project name"
+                class="cnp-input" data-test="new-project-name-input" />
             </div>
           </div>
 
-          <div style="position:absolute; top:10px; right:10px; cursor: pointer;" data-click="onExitBigFeedItemClicked">
-            <div class="projects-exit-big-feed-item-icon">
-              <i class="hgi-stroke hgi-cancel-01" style="font-size: 14px; color: rgba(255,255,255,0.7);"></i>
-            </div>
-          </div>
         </div>
       </div>
 
-      <div style="position:absolute; bottom:5px; right:20px; margin-top: 10px;">
+      <div class="cnp-footer">
+        <button class="cnp-cancel" data-click="onExitBigFeedItemClicked">Cancel</button>
         <button id="create-new-project-button" class="projects-create-new-project-button"
-          data-test="create-project-from-template-button"
-          style="margin-right:10px; float:right; display: flex; align-items: center; gap: 8px;"
-          data-click="onNewProjectFromSampleClicked">
+          data-test="create-project-from-template-button" data-click="onNewProjectFromSampleClicked">
           <span class="button-text">Select project folder location</span>
           <div class="button-spinner" style="display: none;">
             <div class="spinner-dot"></div>

--- a/packages/xgenia-editor/src/editor/src/views/projectsview.ts
+++ b/packages/xgenia-editor/src/editor/src/views/projectsview.ts
@@ -27,6 +27,17 @@ const ProjectsViewTemplate = require('../templates/projectsview.html');
 
 // Styles
 require('../styles/projectsview.css');
+
+// Shown in the create-project popup when a template has no preview image (or it fails to
+// load). Inline SVG rather than an icon font: the editor ships no icon webfont, so the old
+// <span class="material-icons-outlined">image</span> rendered as the literal word "image".
+const TEMPLATE_PREVIEW_PLACEHOLDER =
+  '<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.35)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<rect x="3" y="3" width="18" height="18" rx="3"></rect>' +
+  '<circle cx="8.75" cy="8.75" r="1.5"></circle>' +
+  '<path d="M3.5 16.5 8 12.5l3.5 3 3-2.5 6 5.5"></path>' +
+  '</svg>';
+
 require('../styles/projectsview.lessoncards.css');
 
 const _cache = {};
@@ -1195,12 +1206,12 @@ export class ProjectsView extends View {
           this.$('#start-pane-feed-item-big-image').css('background-image', 'url(' + uri + ')');
         } else {
           // Show a placeholder when image fails to load
-          this.$('#start-pane-feed-item-big-image').html('<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-secondary);"><span class="material-icons-outlined" style="font-size: 48px;">image</span></div>');
+          this.$('#start-pane-feed-item-big-image').html(TEMPLATE_PREVIEW_PLACEHOLDER);
         }
       });
     } else {
       // Show a placeholder when no image URL is provided
-      this.$('#start-pane-feed-item-big-image').html('<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-secondary);"><span class="material-icons-outlined" style="font-size: 48px;">image</span></div>');
+      this.$('#start-pane-feed-item-big-image').html(TEMPLATE_PREVIEW_PLACEHOLDER);
     }
 
     this.$('#create-new-project-button').prop(
@@ -1253,12 +1264,12 @@ export class ProjectsView extends View {
           _this.$('#start-pane-feed-item-big-image').css('background-image', 'url(' + uri + ')');
         } else {
           // Show a placeholder when image fails to load
-          _this.$('#start-pane-feed-item-big-image').html('<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-secondary);"><span class="material-icons-outlined" style="font-size: 48px;">image</span></div>');
+          _this.$('#start-pane-feed-item-big-image').html(TEMPLATE_PREVIEW_PLACEHOLDER);
         }
       });
     } else {
       // Show a placeholder when no image URL is provided
-      this.$('#start-pane-feed-item-big-image').html('<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-secondary);"><span class="material-icons-outlined" style="font-size: 48px;">image</span></div>');
+      this.$('#start-pane-feed-item-big-image').html(TEMPLATE_PREVIEW_PLACEHOLDER);
     }
 
     // this._setupCloudServicesSelection(scope);


### PR DESCRIPTION
The create-project popup was positioned with absolute offsets and fixed widths. In the blank / "Start with AI" flow the 250px preview is hidden, which left a 350px input inside a 440px card and a button absolutely positioned at `bottom:5px; right:20px` — input, button and card padding all landed on different lines, with dead space between them.

Rebuilt the same card as a flex layout:

- `.cnp-body` + `.cnp-footer` (divider, CTA right-aligned with a Cancel next to it). No absolute button, no fixed input width, consistent 32px gutters in both modes.
- Input is a 40px pill that fills the column, with a focus ring. Label is 11px uppercase; title is 18/600 sentence case (was `text-transform: capitalize` at 1.5rem/700, so it read "Create New Project").
- Blank mode is a 440px card; template mode is 720px with the 200px preview.
- Primary CTA styling scoped to the modal — `projects-create-new-project-button` is shared with the full-width neutral sidebar button, which was overriding the accent fill.
- `popupIn` no longer carries `translateY(-50%)`, since the card is centred by flex rather than an absolute offset.
- The template preview placeholder was `<span class="material-icons-outlined">image</span>`; no icon webfont ships in the editor, so it rendered the literal word "image". Replaced with inline SVG.

Verified by rendering the real template + CSS in headless Chrome in both modes. `tsc --noEmit` on xgenia-editor reports 177 errors, all pre-existing, none in projectsview.ts.